### PR TITLE
Refactor parser

### DIFF
--- a/slox/ParseError.swift
+++ b/slox/ParseError.swift
@@ -34,7 +34,6 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
     case missingDotAfterSuper(Token)
     case expectedSuperclassMethodName(Token)
     case missingCloseBracketForSubscriptAccess(Token)
-    case unsupportedJumpStatement(Token)
 
     var description: String {
         switch self {
@@ -90,8 +89,6 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(token.line)] Error: expected superclass method name"
         case .missingCloseBracketForSubscriptAccess(let token):
             return "[Line \(token.line)] Error: expected closing bracket after subscript index"
-        case .unsupportedJumpStatement(let token):
-            return "[Line \(token.line)] Error: unsupported jump statement"
         }
     }
 }

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -195,8 +195,8 @@ struct Parser {
             return printStmt
         }
 
-        if [.return, .break, .continue].contains(currentToken.type) {
-            return try parseJumpStatement()
+        if let jumpStmt = try parseJumpStatement() {
+            return jumpStmt
         }
 
         if currentTokenMatchesAny(types: [.while]) {
@@ -287,7 +287,7 @@ struct Parser {
         throw ParseError.missingSemicolon(currentToken)
     }
 
-    mutating private func parseJumpStatement() throws -> Statement {
+    mutating private func parseJumpStatement() throws -> Statement? {
         if currentTokenMatchesAny(types: [.return]) {
             let returnToken = previousToken
 
@@ -323,7 +323,7 @@ struct Parser {
             return .continue(continueToken)
         }
 
-        throw ParseError.unsupportedJumpStatement(currentToken)
+        return nil
     }
 
     mutating private func parseWhileStatement() throws -> Statement {

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -199,8 +199,8 @@ struct Parser {
             return jumpStmt
         }
 
-        if currentTokenMatchesAny(types: [.while]) {
-            return try parseWhileStatement()
+        if let whileStmt = try parseWhileStatement() {
+            return whileStmt
         }
 
         if currentTokenMatchesAny(types: [.leftBrace]) {
@@ -326,7 +326,11 @@ struct Parser {
         return nil
     }
 
-    mutating private func parseWhileStatement() throws -> Statement {
+    mutating private func parseWhileStatement() throws -> Statement? {
+        guard currentTokenMatchesAny(types: [.while]) else {
+            return nil
+        }
+
         if !currentTokenMatchesAny(types: [.leftParen]) {
             throw ParseError.missingOpenParenForWhileStatement(currentToken)
         }

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -183,16 +183,16 @@ struct Parser {
     }
 
     mutating private func parseStatement() throws -> Statement {
-        if currentTokenMatchesAny(types: [.for]) {
-            return try parseForStatement()
+        if let forStmt = try parseForStatement() {
+            return forStmt
         }
 
-        if currentTokenMatchesAny(types: [.if]) {
-            return try parseIfStatement()
+        if let ifStmt = try parseIfStatement() {
+            return ifStmt
         }
 
-        if currentTokenMatchesAny(types: [.print]) {
-            return try parsePrintStatement()
+        if let printStmt = try parsePrintStatement() {
+            return printStmt
         }
 
         if [.return, .break, .continue].contains(currentToken.type) {
@@ -211,7 +211,11 @@ struct Parser {
         return try parseExpressionStatement()
     }
 
-    mutating private func parseForStatement() throws -> Statement {
+    mutating private func parseForStatement() throws -> Statement? {
+        guard currentTokenMatchesAny(types: [.for]) else {
+            return nil
+        }
+
         if !currentTokenMatchesAny(types: [.leftParen]) {
             throw ParseError.missingOpenParenForForStatement(currentToken)
         }
@@ -246,7 +250,11 @@ struct Parser {
         return .for(initializerStmt, testExpr, incrementExpr, bodyStmt)
     }
 
-    mutating private func parseIfStatement() throws -> Statement {
+    mutating private func parseIfStatement() throws -> Statement? {
+        guard currentTokenMatchesAny(types: [.if]) else {
+            return nil
+        }
+
         if !currentTokenMatchesAny(types: [.leftParen]) {
             throw ParseError.missingOpenParenForIfStatement(currentToken)
         }
@@ -266,7 +274,11 @@ struct Parser {
         return .if(testExpr, consequentStmt, alternativeStmt)
     }
 
-    mutating private func parsePrintStatement() throws -> Statement {
+    mutating private func parsePrintStatement() throws -> Statement? {
+        guard currentTokenMatchesAny(types: [.print]) else {
+            return nil
+        }
+
         let expr = try parseExpression()
         if currentTokenMatchesAny(types: [.semicolon]) {
             return .print(expr)

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -386,11 +386,11 @@ struct Parser {
         // then we want to return that immediately so it can be evaluated
         // and whose result can be printed in the REPL, and without burdening
         // the user to add a semicolon at the end.
-        if currentToken.type == .eof || currentTokenMatchesAny(types: [.semicolon]) {
-            return .expression(expr)
+        guard currentToken.type == .eof || currentTokenMatchesAny(types: [.semicolon]) else {
+            throw ParseError.missingSemicolon(currentToken)
         }
 
-        throw ParseError.missingSemicolon(currentToken)
+        return .expression(expr)
     }
 
     // The parsing strategy below follows these rules of precedence


### PR DESCRIPTION
There are two main objectives in the PR:

* Centralize the logic associated with any one helper. For example, the detection of a "class" token should actually be part of the helper for parsing a class declaration. That necessitated that said helpers needed to return a nilable `Statement` or `Expression` in the event the detection of the first token wasn't made, which meant that call sites needed to have an `if let` block to capture and return a non-nil value. This not only improved clarity, but also improved the reusability of such helpers.
* Introduce new helpers, and move out logic for parsing various statements and expressions into them. For example, `parsePostfix()` had logic for handling any of three expression types, making the method harder to read and understand. Moving each bundle of logic into its own method, namely `parseCall()`, `parseGet()`, and `parseSubscript()`, and giving each a name makes intent much clearer.
* Introduced `consumeToken()` to reduce boilerplate and the number of places the low-level call to `advanceCursor()` were made.
* Ensured that the last statement in every helper returned a value instead of throwing an error. In those cases, I introduced a `guard` block to throw that error, and if control fell through, then the value would be returned at the end of the function block. This also (hopefully) improves clarity.