### PR TITLE
Centralize list methods in `LoxList`

### DIFF
--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -435,6 +435,10 @@ class Interpreter {
                                       args: [ResolvedExpression]) throws -> LoxValue {
         let callee = try evaluate(expr: calleeExpr)
 
+        if case .instance(let klass as LoxClass) = callee, klass.name == "List" {
+            return try handleListExpression(elements: args)
+        }
+
         let actualCallable: LoxCallable = switch callee {
         case .userDefinedFunction(let userDefinedFunction):
             userDefinedFunction

--- a/slox/LoxInstance.swift
+++ b/slox/LoxInstance.swift
@@ -5,7 +5,7 @@
 //  Created by Danielle Kefford on 3/4/24.
 //
 
-class LoxInstance: Equatable {
+class LoxInstance {
     // `klass` is what is used in the interpreter when we need
     // to know the class of a particular instance. Every Lox
     // instance, including Lox classes, need to have a non-nil
@@ -47,9 +47,5 @@ class LoxInstance: Equatable {
 
     func set(propertyName: String, propertyValue: LoxValue) throws {
         self.properties[propertyName] = propertyValue
-    }
-
-    static func == (lhs: LoxInstance, rhs: LoxInstance) -> Bool {
-        return lhs === rhs
     }
 }

--- a/slox/LoxValue.swift
+++ b/slox/LoxValue.swift
@@ -13,6 +13,7 @@ enum LoxValue: CustomStringConvertible, Equatable {
     case userDefinedFunction(UserDefinedFunction)
     case nativeFunction(NativeFunction)
     case instance(LoxInstance)
+    case callable(LoxCallable)
 
     var description: String {
         switch self {
@@ -42,6 +43,8 @@ enum LoxValue: CustomStringConvertible, Equatable {
             return string
         case .instance(let instance):
             return "<instance: \(instance.klass.name)>"
+        case .callable:
+            return "<callable>"
         }
     }
 
@@ -72,6 +75,22 @@ enum LoxValue: CustomStringConvertible, Equatable {
             return boolean
         default:
             return true
+        }
+    }
+
+    // NOTA BENE: This equality conformance is only for unit tests
+    static func == (lhs: LoxValue, rhs: LoxValue) -> Bool {
+        switch (lhs, rhs) {
+        case (.string(let lhsString), .string(let rhsString)):
+            return lhsString == rhsString
+        case (.number(let lhsNumber), .number(let rhsNumber)):
+            return lhsNumber == rhsNumber
+        case (.boolean(let lhsBoolean), .boolean(let rhsBoolean)):
+            return lhsBoolean == rhsBoolean
+        case (.nil, .nil):
+            return true
+        default:
+            return false
         }
     }
 }

--- a/slox/NativeFunction.swift
+++ b/slox/NativeFunction.swift
@@ -9,17 +9,11 @@ import Foundation
 
 enum NativeFunction: LoxCallable, Equatable, CaseIterable {
     case clock
-    case appendNative
-    case deleteAtNative
 
     var arity: Int {
         switch self {
         case .clock:
             return 0
-        case .appendNative:
-            return 2
-        case .deleteAtNative:
-            return 2
         }
     }
 
@@ -27,25 +21,6 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
         switch self {
         case .clock:
             return .number(Date().timeIntervalSince1970)
-        case .appendNative:
-            guard case .instance(let loxList as LoxList) = args[0] else {
-                throw RuntimeError.notAList
-            }
-
-            let element = args[1]
-            loxList.elements.append(element)
-
-            return .nil
-        case .deleteAtNative:
-            guard case .instance(let loxList as LoxList) = args[0] else {
-                throw RuntimeError.notAList
-            }
-
-            guard case .number(let index) = args[1] else {
-                throw RuntimeError.indexMustBeANumber
-            }
-
-            return loxList.elements.remove(at: Int(index))
         }
     }
 }


### PR DESCRIPTION
* Created private inner classes inside `LoxList`, one for representing the `append()` method and the other for the `deleteAt()` method, both of which implement `LoxCallable` and are instantiated and returned when the correspondent `LoxList` property is retrieved. The two inner classes are passed a reference to the outer `LoxList` instance such that they can access/mutate its elements.
* For the time being, the `standardLibrary` string previously defined in `Interpreter` is no longer needed, as all necessary plumbing is centralized in `LoxList`, and so there is no more hidden `List` class to instantiate. Perhaps in the future, we can reinstate it when we build things _on top_ of existing infrastructure instead of being foundational but needing to access features in the Swift layer that are _not_ expressible in Lox code.
* Since there is no more `List` class, there is no need for `appendNative` and `deleteAtNative` cases in `NativeFunction`
* The `LoxValue` enum now has a `callable` case for a third class of functions, for the time being to represent methods of a specialized Lox class. The other two extant cases just didn't quite work:
  * a `UserDefinedFunction`, although gets passed an `Environment` through its constructor, also needs to be passed `ResolvedStatement`s as its body, which would be awkward to express in the interpreter when bootstrapping. Moreover, there is no way to express new language features in Lox itself, which is the central to the problem we're trying to solve.
  * a `NativeFunction` does not have access to an environment and thus no way to get a handle to the instance whose method is being invoked. It really is intended to represent a standalone function like `clock()`. It also didn't make sense to add a `klass` property to `NativeFunction` since it would be nonsensical for things like `clock()` which are not bound to a class.
* In order to introduce the `callable` case into `LoxValue`, I needed to be able to have the latter conform to `Equatable` explicitly. This conformance is only meaningful in the context of a unit test, in which I need to be able to compare ASTs in many cases.