### PR TITLE
Second attempt at closing loophole

### DIFF
--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -589,7 +589,7 @@ class Interpreter {
         return value
     }
 
-    private func makeList(elements: [LoxValue]) throws -> LoxValue {
+    func makeList(elements: [LoxValue]) throws -> LoxValue {
         guard case .instance(let listClass as LoxClass) = try environment.getValue(name: "List") else {
             fatalError()
         }

--- a/slox/LoxClass.swift
+++ b/slox/LoxClass.swift
@@ -16,13 +16,28 @@ class LoxClass: LoxInstance, LoxCallable {
         return 0
     }
     var methods: [String: UserDefinedFunction]
+    var instanceType: LoxInstance.Type {
+        if self.name == "List" {
+            LoxList.self
+        } else {
+            LoxInstance.self
+        }
+    }
 
-    init(name: String, superclass: LoxClass?, methods: [String: UserDefinedFunction]) {
+    convenience init(name: String, superclass: LoxClass?, methods: [String: UserDefinedFunction]) {
+        self.init(klass: nil)
+
         self.name = name
         self.superclass = superclass
         self.methods = methods
+    }
 
-        super.init(klass: nil)
+    required init(klass: LoxClass?) {
+        self.name = "(anonymous)"
+        self.superclass = nil
+        self.methods = [:]
+
+        super.init(klass: klass)
     }
 
     static func == (lhs: LoxClass, rhs: LoxClass) -> Bool {
@@ -38,7 +53,7 @@ class LoxClass: LoxInstance, LoxCallable {
     }
 
     func call(interpreter: Interpreter, args: [LoxValue]) throws -> LoxValue {
-        let newInstance = LoxInstance(klass: self)
+        let newInstance = instanceType.init(klass: self)
 
         if let initializer = methods["init"] {
             let boundInit = initializer.bind(instance: newInstance)

--- a/slox/LoxClass.swift
+++ b/slox/LoxClass.swift
@@ -40,10 +40,6 @@ class LoxClass: LoxInstance, LoxCallable {
         super.init(klass: klass)
     }
 
-    static func == (lhs: LoxClass, rhs: LoxClass) -> Bool {
-        return lhs === rhs
-    }
-
     func findMethod(name: String) -> UserDefinedFunction? {
         if let method = methods[name] {
             return method

--- a/slox/LoxInstance.swift
+++ b/slox/LoxInstance.swift
@@ -5,7 +5,7 @@
 //  Created by Danielle Kefford on 3/4/24.
 //
 
-class LoxInstance: Equatable {
+class LoxInstance {
     // `klass` is what is used in the interpreter when we need
     // to know the class of a particular instance. Every Lox
     // instance, including Lox classes, need to have a non-nil
@@ -47,9 +47,5 @@ class LoxInstance: Equatable {
 
     func set(propertyName: String, propertyValue: LoxValue) throws {
         self.properties[propertyName] = propertyValue
-    }
-
-    static func == (lhs: LoxInstance, rhs: LoxInstance) -> Bool {
-        return lhs === rhs
     }
 }

--- a/slox/LoxInstance.swift
+++ b/slox/LoxInstance.swift
@@ -28,7 +28,7 @@ class LoxInstance: Equatable {
     /// - Parameter klass: The class this instance belongs to.
     /// Use `nil` if this instance *is* a class; the `klass` property
     /// will then instantiate a metaclass for it on demand.
-    init(klass: LoxClass?) {
+    required init(klass: LoxClass?) {
         self._klass = klass
     }
 

--- a/slox/LoxList.swift
+++ b/slox/LoxList.swift
@@ -34,10 +34,6 @@ class LoxList: LoxInstance {
         throw RuntimeError.onlyInstancesHaveProperties
     }
 
-    static func == (lhs: LoxList, rhs: LoxList) -> Bool {
-        return lhs.elements == rhs.elements
-    }
-
     // TODO: Need to think about how to handle invalid indices!!!
     subscript(index: Int) -> LoxValue {
         get {

--- a/slox/LoxList.swift
+++ b/slox/LoxList.swift
@@ -11,8 +11,13 @@ class LoxList: LoxInstance {
         return elements.count
     }
 
-    init(elements: [LoxValue], klass: LoxClass) {
+    convenience init(elements: [LoxValue], klass: LoxClass) {
+        self.init(klass: klass)
         self.elements = elements
+    }
+
+    required init(klass: LoxClass?) {
+        self.elements = []
         super.init(klass: klass)
     }
 

--- a/slox/LoxValue.swift
+++ b/slox/LoxValue.swift
@@ -66,7 +66,7 @@ enum LoxValue: CustomStringConvertible, Equatable {
         case (.boolean(let leftBoolean), .boolean(let rightBoolean)):
             return leftBoolean == rightBoolean
         case (.instance(let leftList as LoxList), .instance(let rightList as LoxList)):
-            return leftList == rightList
+            return leftList.elements == rightList.elements
         default:
             return false
         }
@@ -103,6 +103,28 @@ enum LoxValue: CustomStringConvertible, Equatable {
             return number
         default:
             throw RuntimeError.notANumber
+        }
+    }
+
+    // NOTA BENE: This equality conformance is only for unit tests
+    static func == (lhs: LoxValue, rhs: LoxValue) -> Bool {
+        switch (lhs, rhs) {
+        case (.string(let lhsString), .string(let rhsString)):
+            return lhsString == rhsString
+        case (.int(let lhsNumber), .int(let rhsNumber)):
+            return lhsNumber == rhsNumber
+        case (.int, .double), (.double, .int), (.double, .double):
+            let leftNumber = try! lhs.convertToRawDouble()
+            let rightNumber = try! rhs.convertToRawDouble()
+            return leftNumber == rightNumber
+        case (.boolean(let lhsBoolean), .boolean(let rhsBoolean)):
+            return lhsBoolean == rhsBoolean
+        case (.nil, .nil):
+            return true
+        case (.instance(let leftList as LoxList), .instance(let rightList as LoxList)):
+            return leftList.elements == rightList.elements
+        default:
+            return false
         }
     }
 }

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -515,19 +515,15 @@ xyzzy
 """
 
         let interpreter = Interpreter()
-        guard case .instance(let list as LoxList) = try interpreter.interpretRepl(source: input) else {
-            XCTFail()
-            return
-        }
-        let actual = list.elements
-        let expected: [LoxValue] = [
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected = try interpreter.makeList(elements: [
             .int(1),
             .int(2),
             .int(3),
             .int(4),
             .int(5),
             .int(6),
-        ]
+        ])
         XCTAssertEqual(actual, expected)
     }
 
@@ -538,12 +534,8 @@ foo
 """
 
         let interpreter = Interpreter()
-        guard case .instance(let list as LoxList) = try interpreter.interpretRepl(source: input) else {
-            XCTFail()
-            return
-        }
-        let actual = list.elements
-        let expected: [LoxValue] = []
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected = try interpreter.makeList(elements: [])
         XCTAssertEqual(actual, expected)
     }
 

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -531,6 +531,22 @@ xyzzy
         XCTAssertEqual(actual, expected)
     }
 
+    func testInterpretCreatingListFromConstructor() throws {
+        let input = """
+var foo = List();
+foo
+"""
+
+        let interpreter = Interpreter()
+        guard case .instance(let list as LoxList) = try interpreter.interpretRepl(source: input) else {
+            XCTFail()
+            return
+        }
+        let actual = list.elements
+        let expected: [LoxValue] = []
+        XCTAssertEqual(actual, expected)
+    }
+
     func testInterpretExpressionWithListSubscriptingMethodInvocationAndPropertyGetting() throws {
         let input = """
 class Foo { }


### PR DESCRIPTION
To clarify, the loophole was that although the user could properly create instances of `LoxList` by using bracket notation for a list literal in the REPL, they could also explicitly create an instance of `List`. This would result in an object in a hybrid state, without an `elements` property and no way to modify it to behave like an actual list. In this PR, we introduced the `instanceType` property for `LoxClass` so that when instances of it are created via `LoxClass.call()`, we create a `LoxList` instance if the class' name is `List`, and `LoxInstance` instance otherwise. This is what closes the loophole. (It should be noted that the name gets set to `List` when the interpreter is first instantiated and processes the class declaration for `List` in the standard library.)

We also included the following changes:

* Introduced `makeList()` in `Interpreter` to get rid of code duplication but also made it public so that it could be used in unit tests
* Moved equality conformance to `LoxValue`, which is used only for unit testing, for clarity