### PR TITLE
Implement computed properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ So far, the following have been implemented in `slox`:
 - List literals using square brackets
 - Native functions for lists, `append()` and `deleteAt()`
 - `break` and `continue` for flow control within loops
+- Computed properties (inside classes, not at the top-level)
 
 # Design
 
@@ -38,7 +39,7 @@ Most of the design of `slox` is fairly similar to the one in the book. There are
 - resolving of variables from parsed code
 - interpreting of resolved statements 
 
-However, unlike how they are implemented in the book, the REPL and file runner instantiate just the interpreter, passing in code to be executed; it is the interpreter that instantiates and runs each of the scanner, parser, resolver in succession, each feeding their results to the next. The interpreter also reads in a small standard library defined in a string; at this point, only a class declaration for a `List` class and some associated methods are defined in it.
+However, unlike how they are implemented in the book, the REPL and file runner instantiate just the interpreter, passing in code to be executed; it is the interpreter that instantiates and runs the scanner, parser, resolver in succession, each feeding their results to the next. The interpreter also reads in a small standard library defined in a string; at this point, only a class declaration for a `List` class and some associated methods are defined in it.
 
 There are a few other differences between this implementation and that in the book which are described below.
 

--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -14,7 +14,7 @@ indirect enum Expression: Equatable {
     case assignment(Token, Expression)
     case logical(Expression, Token, Expression)
     case call(Expression, Token, [Expression])
-    case lambda([Token], [Statement])
+    case lambda([Token]?, [Statement])
     case get(Expression, Token)
     case set(Expression, Token, Expression)
     case this(Token)

--- a/slox/LoxClass.swift
+++ b/slox/LoxClass.swift
@@ -10,7 +10,7 @@ class LoxClass: LoxInstance, LoxCallable {
     var superclass: LoxClass?
     var arity: Int {
         if let initializer = methods["init"] {
-            return initializer.params.count
+            return initializer.arity
         }
 
         return 0

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -138,12 +138,12 @@ struct Parser {
             throw ParseError.missingFunctionName(currentToken)
         }
 
-        if !currentTokenMatchesAny(types: [.leftParen]) {
-            throw ParseError.missingOpenParenForFunctionDeclaration(currentToken)
-        }
-        let parameters = try parseParameters()
-        if !currentTokenMatchesAny(types: [.rightParen]) {
-            throw ParseError.missingCloseParenAfterArguments(currentToken)
+        var parameters: [Token]? = nil
+        if currentTokenMatchesAny(types: [.leftParen]) {
+            parameters = try parseParameters()
+            if !currentTokenMatchesAny(types: [.rightParen]) {
+                throw ParseError.missingCloseParenAfterArguments(currentToken)
+            }
         }
 
         guard let functionBody = try parseBlock() else {

--- a/slox/ResolvedExpression.swift
+++ b/slox/ResolvedExpression.swift
@@ -14,7 +14,7 @@ indirect enum ResolvedExpression: Equatable {
     case assignment(Token, ResolvedExpression, Int)
     case logical(ResolvedExpression, Token, ResolvedExpression)
     case call(ResolvedExpression, Token, [ResolvedExpression])
-    case lambda([Token], [ResolvedStatement])
+    case lambda([Token]?, [ResolvedStatement])
     case get(ResolvedExpression, Token)
     case set(ResolvedExpression, Token, ResolvedExpression)
     case this(Token, Int)

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -437,6 +437,8 @@ struct Resolver {
                 try declareVariable(name: param.lexeme)
                 defineVariable(name: param.lexeme)
             }
+        } else if currentClassType == .none {
+            throw ResolverError.functionsMustHaveAParameterList
         }
 
         let resolvedStatements = try statements.map { statement in

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -418,7 +418,7 @@ struct Resolver {
         return .logical(resolvedLeftExpr, operToken, resolvedRightExpr)
     }
 
-    mutating private func handleLambda(params: [Token],
+    mutating private func handleLambda(params: [Token]?,
                                        statements: [Statement],
                                        functionType: FunctionType) throws -> ResolvedExpression {
         beginScope()
@@ -432,9 +432,11 @@ struct Resolver {
             currentLoopType = previousLoopType
         }
 
-        for param in params {
-            try declareVariable(name: param.lexeme)
-            defineVariable(name: param.lexeme)
+        if let params {
+            for param in params {
+                try declareVariable(name: param.lexeme)
+                defineVariable(name: param.lexeme)
+            }
         }
 
         let resolvedStatements = try statements.map { statement in

--- a/slox/ResolverError.swift
+++ b/slox/ResolverError.swift
@@ -20,6 +20,7 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
     case cannotReferenceSuperWithoutSubclassing
     case cannotBreakOutsideLoop
     case cannotContinueOutsideLoop
+    case functionsMustHaveAParameterList
 
     var description: String {
         switch self {
@@ -47,6 +48,8 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
             return "Can only `break` from inside a `while` or `for` loop"
         case .cannotContinueOutsideLoop:
             return "Can only `continue` from inside a `while` or `for` loop"
+        case .functionsMustHaveAParameterList:
+            return "Functions must have a parameter list"
         }
     }
 }

--- a/slox/UserDefinedFunction.swift
+++ b/slox/UserDefinedFunction.swift
@@ -7,19 +7,28 @@
 
 struct UserDefinedFunction: LoxCallable, Equatable {
     var name: String
-    var params: [Token]
-    var arity: Int {
-        return params.count
-    }
+    var params: [Token]?
     var enclosingEnvironment: Environment
     var body: [ResolvedStatement]
     var isInitializer: Bool
+    var arity: Int {
+        if let params {
+            return params.count
+        } else {
+            return 0
+        }
+    }
+    var isComputedProperty: Bool {
+        return params == nil
+    }
 
     func call(interpreter: Interpreter, args: [LoxValue]) throws -> LoxValue {
         let newEnvironment = Environment(enclosingEnvironment: enclosingEnvironment)
 
-        for (i, arg) in args.enumerated() {
-            newEnvironment.define(name: params[i].lexeme, value: arg)
+        if let params {
+            for (i, arg) in args.enumerated() {
+                newEnvironment.define(name: params[i].lexeme, value: arg)
+            }
         }
 
         do {

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -428,6 +428,27 @@ b.method()
         XCTAssertEqual(actual, expected)
     }
 
+    func testInterpretAccessingComputedPropertyOfClass() throws {
+        let input = """
+class Circle {
+    init(radius) {
+        this.radius = radius;
+    }
+
+    area {
+        return 3.14159 * this.radius * this.radius;
+    }
+}
+var c = Circle(4);
+c.area
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .double(50.26544)
+        XCTAssertEqual(actual, expected)
+    }
+
     func testInterpretAccessingElementOfList() throws {
         let input = """
 var foo = [1, 2, 3, 4, 5];

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -1191,6 +1191,70 @@ final class ParserTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    func testParseClassWithComputedProperty() throws {
+        // class Circle {
+        //     area {
+        //         return 3.14159 * this.radius * this.radius;
+        //     }
+        // }
+        let tokens: [Token] = [
+            Token(type: .class, lexeme: "class", line: 1),
+            Token(type: .identifier, lexeme: "Circle", line: 1),
+            Token(type: .leftBrace, lexeme: "{", line: 1),
+
+            Token(type: .identifier, lexeme: "area", line: 2),
+            Token(type: .leftBrace, lexeme: "{", line: 2),
+
+            Token(type: .return, lexeme: "return", line: 3),
+            Token(type: .double, lexeme: "3.14159", line: 3),
+            Token(type: .star, lexeme: "*", line: 3),
+            Token(type: .this, lexeme: "this", line: 3),
+            Token(type: .dot, lexeme: ".", line: 3),
+            Token(type: .identifier, lexeme: "radius", line: 3),
+            Token(type: .star, lexeme: "*", line: 3),
+            Token(type: .this, lexeme: "this", line: 3),
+            Token(type: .dot, lexeme: ".", line: 3),
+            Token(type: .identifier, lexeme: "radius", line: 3),
+            Token(type: .semicolon, lexeme: ";", line: 3),
+
+            Token(type: .rightBrace, lexeme: "}", line: 4),
+
+            Token(type: .rightBrace, lexeme: "}", line: 5),
+            Token(type: .eof, lexeme: "", line: 5),
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let actual = try parser.parse()
+        let expected: [Statement] = [
+            .class(
+                Token(type: .identifier, lexeme: "Circle", line: 1),
+                nil,
+                [
+                    .function(
+                        Token(type: .identifier, lexeme: "area", line: 2),
+                        .lambda(
+                            nil,
+                            [
+                                .return(
+                                    Token(type: .return, lexeme: "return", line: 3),
+                                    .binary(
+                                        .binary(
+                                            .literal(.double(3.14159)),
+                                            Token(type: .star, lexeme: "*", line: 3),
+                                            .get(
+                                                .this(Token(type: .this, lexeme: "this", line: 3)),
+                                                Token(type: .identifier, lexeme: "radius", line: 3))),
+                                        Token(type: .star, lexeme: "*", line: 3),
+                                        .get(
+                                            .this(Token(type: .this, lexeme: "this", line: 3)),
+                                            Token(type: .identifier, lexeme: "radius", line: 3)))),
+                            ]))
+                ],
+                [])
+        ]
+        XCTAssertEqual(actual, expected)
+    }
+
     func testParseListOfValues() throws {
         // [1, "one", true]
         let tokens: [Token] = [

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -94,6 +94,29 @@ final class ResolverTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    func testResolveFunctionDeclarationWithoutParameterList() throws {
+        // fun answer {
+        //     return 42;
+        // }
+        let statements: [Statement] = [
+            .function(
+                Token(type: .identifier, lexeme: "answer", line: 1),
+                .lambda(
+                    nil,
+                    [
+                        .return(
+                            Token(type: .return, lexeme: "return", line: 2),
+                            .literal(.int(42)))
+                    ])),
+        ]
+
+        var resolver = Resolver()
+        let expectedError = ResolverError.functionsMustHaveAParameterList
+        XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
+            XCTAssertEqual(actualError as! ResolverError, expectedError)
+        }
+    }
+
     func testResolveVariableExpressionInDeeplyNestedBlock() throws {
         // var becca; {{{ becca = "awesome"; }}}
         let statements: [Statement] = [


### PR DESCRIPTION
This PR allows for so-called computed properties for classes. Specifically, they are like functions in that they have a body of statements which return a value, but they do not take any parameters and they are evaluated eagerly (i.e., they do not require parentheses after the name to invoke a call). The following is an example:

```
class Circle {
    init(radius) {
        this.radius = radius;
    }

    area {
        return 3.14149 * this.radius * this.radius;
    }
}
```

Once such a class is initialized, the computed property can be accessed like this:

```
var c = Circle(4.0);
c.area // returns 50.26544
```

The following changes were made in order to accomplish this:

* the list of parameter `Token`s associated with the `.lambda` expression (and resolved expression as well) is now optional
* the parser now allows for a non-existent parameter list when parsing a function, and sets the parameter list to `nil` if handing a computer property
* the resolver now checks to see if the parameter list is null, and only resolves them if the list is not null
* likewise, the list of parameter `Token`s associated with `UserDefinedFunction` is also optional
* there is a new `isComputedProperty` property in `UserDefinedFunction` that the interpreter can now use instead of accessing `params` directly
* the `call()` method in `UserDefinedFunction` will only process arguments if the parameter list is non-nil, i.e., it represents a computed property
* `Interpreter.handleGetExpression()` now tests to see if the fetched object is a computed property and immediately evaluates and returns the value if that is the case, and otherwise returns the object as is.

For the time being, computed properties will only be supported within a class and not at the top level.
