### PR TITLE
Add compound assignment operators

### DIFF
--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -432,6 +432,8 @@ struct Parser {
                 return .assignment(name, valueExpr)
             } else if case .get(let instanceExpr, let propertyNameToken) = expr {
                 return .set(instanceExpr, propertyNameToken, valueExpr)
+            } else if case .subscriptGet(let listExpr, let indexExpr) = expr {
+                return .subscriptSet(listExpr, indexExpr, valueExpr)
             }
 
             throw ParseError.invalidAssignmentTarget(equalToken)
@@ -582,11 +584,6 @@ struct Parser {
 
         guard currentTokenMatchesAny(types: [.rightBracket]) else {
             throw ParseError.missingCloseBracketForSubscriptAccess(currentToken)
-        }
-
-        if currentTokenMatchesAny(types: [.equal]) {
-            let valueExpr = try parseExpression()
-            return .subscriptSet(expr, indexExpr, valueExpr)
         }
 
         return .subscriptGet(expr, indexExpr)

--- a/slox/Scanner.swift
+++ b/slox/Scanner.swift
@@ -74,14 +74,8 @@ struct Scanner {
             handleSingleCharacterLexeme(type: .comma)
         case ".":
             handleSingleCharacterLexeme(type: .dot)
-        case "-":
-            handleSingleCharacterLexeme(type: .minus)
-        case "+":
-            handleSingleCharacterLexeme(type: .plus)
         case ";":
             handleSingleCharacterLexeme(type: .semicolon)
-        case "*":
-            handleSingleCharacterLexeme(type: .star)
         case "%":
             handleSingleCharacterLexeme(type: .modulus)
         case ":":
@@ -98,6 +92,12 @@ struct Scanner {
             handleOneOrTwoCharacterLexeme(oneCharLexeme: .less, twoCharLexeme: .lessEqual)
         case ">":
             handleOneOrTwoCharacterLexeme(oneCharLexeme: .greater, twoCharLexeme: .greaterEqual)
+        case "-":
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .minus, twoCharLexeme: .minusEqual)
+        case "+":
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .plus, twoCharLexeme: .plusEqual)
+        case "*":
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .star, twoCharLexeme: .starEqual)
 
         // Whitespace
         case " ", "\r", "\t":
@@ -133,7 +133,7 @@ struct Scanner {
                 advanceCursor()
             }
         } else {
-            addToken(type: .slash)
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .slash, twoCharLexeme: .slashEqual)
         }
     }
 

--- a/slox/TokenType.swift
+++ b/slox/TokenType.swift
@@ -13,17 +13,13 @@ enum TokenType: Equatable {
     case rightBrace
     case comma
     case dot
-    case minus
-    case plus
     case semicolon
-    case slash
-    case star
     case leftBracket
     case rightBracket
     case modulus
     case colon
 
-    // One of two character tokens
+    // One or two character tokens
     case bang
     case bangEqual
     case equal
@@ -32,6 +28,14 @@ enum TokenType: Equatable {
     case greaterEqual
     case less
     case lessEqual
+    case minus
+    case minusEqual
+    case plus
+    case plusEqual
+    case slash
+    case slashEqual
+    case star
+    case starEqual
 
     // Literals
     case identifier

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -148,6 +148,19 @@ final class InterpreterTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    func testInterpretUsageOfCompoundAssignmentOperator() throws {
+        let input = """
+var foo = 2;
+foo += 40;
+foo
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .int(42)
+        XCTAssertEqual(actual, expected)
+    }
+
     func testInterpretWhileStatementWithMutationOfVariable() throws {
         let input = """
 var i = 0;
@@ -284,6 +297,21 @@ person.name
         let interpreter = Interpreter()
         let actual = try interpreter.interpretRepl(source: input)
         let expected: LoxValue = .string("Danielle")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretAssignmentOfNewValueToIinstanceProperty() throws {
+        let input = """
+class Universe {}
+var universe = Universe();
+universe.answer = 21;
+universe.answer *= 2;
+universe.answer
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .int(42)
         XCTAssertEqual(actual, expected)
     }
 
@@ -484,6 +512,34 @@ foo[2]
         let interpreter = Interpreter()
         let actual = try interpreter.interpretRepl(source: input)
         let expected: LoxValue = .int(6)
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretMutationOfListViaCompoundAssignmentOperator() throws {
+        let input = """
+var foo = [1, 2, 3, 4, 5];
+foo[2] += 39;
+foo[2]
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .int(42)
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretMutationOfListAsClassProperty() throws {
+        let input = """
+class Foo {}
+var foo = Foo();
+foo.bar = [1, 2, 3];
+foo.bar[1] += 40;
+foo.bar[1]
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .int(42)
         XCTAssertEqual(actual, expected)
     }
 

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -323,6 +323,30 @@ final class ParserTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    func testParseCompoundAssignmentExpression() throws {
+        // foo += 42;
+        let tokens: [Token] = [
+            Token(type: .identifier, lexeme: "foo", line: 1),
+            Token(type: .plusEqual, lexeme: "+=", line: 1),
+            Token(type: .int, lexeme: "42", line: 1),
+            Token(type: .semicolon, lexeme: ";", line: 1),
+            Token(type: .eof, lexeme: "", line: 1),
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let actual = try parser.parse()
+        let expected: [Statement] = [
+            .expression(
+                .assignment(
+                    Token(type: .identifier, lexeme: "foo", line: 1),
+                    .binary(
+                        .variable(Token(type: .identifier, lexeme: "foo", line: 1)),
+                        Token(type: .plus, lexeme: "+", line: 1),
+                        .literal(.int(42)))))
+        ]
+        XCTAssertEqual(actual, expected)
+    }
+
     func testParseComplexExpression() throws {
         // (-2) * (3 + 4);
 

--- a/sloxTests/ScannerTests.swift
+++ b/sloxTests/ScannerTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 final class ScannerTests: XCTestCase {
     func testScanningOfOneCharacterLexemes() throws {
-        let source = "( ) { } [ ] , . - + ; * %"
+        let source = "( ) { } [ ] , . ; %"
         var scanner = Scanner(source: source)
         let actual = try! scanner.scanTokens()
         let expected: [Token] = [
@@ -21,10 +21,7 @@ final class ScannerTests: XCTestCase {
             Token(type: .rightBracket, lexeme: "]", line: 1),
             Token(type: .comma, lexeme: ",", line: 1),
             Token(type: .dot, lexeme: ".", line: 1),
-            Token(type: .minus, lexeme: "-", line: 1),
-            Token(type: .plus, lexeme: "+", line: 1),
             Token(type: .semicolon, lexeme: ";", line: 1),
-            Token(type: .star, lexeme: "*", line: 1),
             Token(type: .modulus, lexeme: "%", line: 1),
             Token(type: .eof, lexeme: "", line: 1),
         ]
@@ -33,7 +30,7 @@ final class ScannerTests: XCTestCase {
     }
 
     func testScanningOfOneOrTwoCharacterLexemes() throws {
-        let source = "! != = == < <= > >="
+        let source = "! != = == < <= > >= + += - -= * *="
         var scanner = Scanner(source: source)
         let actual = try! scanner.scanTokens()
         let expected: [Token] = [
@@ -45,6 +42,12 @@ final class ScannerTests: XCTestCase {
             Token(type: .lessEqual, lexeme: "<=", line: 1),
             Token(type: .greater, lexeme: ">", line: 1),
             Token(type: .greaterEqual, lexeme: ">=", line: 1),
+            Token(type: .plus, lexeme: "+", line: 1),
+            Token(type: .plusEqual, lexeme: "+=", line: 1),
+            Token(type: .minus, lexeme: "-", line: 1),
+            Token(type: .minusEqual, lexeme: "-=", line: 1),
+            Token(type: .star, lexeme: "*", line: 1),
+            Token(type: .starEqual, lexeme: "*=", line: 1),
             Token(type: .eof, lexeme: "", line: 1),
         ]
 
@@ -52,11 +55,12 @@ final class ScannerTests: XCTestCase {
     }
 
     func testScanningOfSlashAndComment() throws {
-        let source = "/ // This should not be lexed"
+        let source = "/ /= // This should not be lexed"
         var scanner = Scanner(source: source)
         let actual = try! scanner.scanTokens()
         let expected: [Token] = [
             Token(type: .slash, lexeme: "/", line: 1),
+            Token(type: .slashEqual, lexeme: "/=", line: 1),
             Token(type: .eof, lexeme: "", line: 1),
         ]
 


### PR DESCRIPTION
This PR allows for compound assignment operators to be used in expressions. `foo += 42` is a little pithier and clearer rather than having to type out `foo = foo + 42`. The following changes were made:

* Introduction of four new token types for `+=`, `-=`, `*=`, and `/=`
* The scanner now handles both the set of original operators, `+`, `-`, `*`, and `/`, and the new ones by using `handleOneOrTwoCharacterLexeme()`
* `parseAssignment()` now handles the new assignment operators by rewriting those expressions in terms of a new binary expression involving the correspondent term or factor operator. For example, `foo += 42` is indeed rewritten as `foo = foo + 42` internally.
* Unit tests not only cover trivial cases but ones involving mutation of lists or instance properties.

There was also a small refactor for handling assignments to subscript expressions in the parser. Previously, the assignment logic was in `parseSubscript()`, which was not in alignment with the way that assignment for other types was handled in `parseAssignment()`, so that logic was moved there.