### PR TITLE
First step towards allowing variadic functions

### DIFF
--- a/slox.xcodeproj/project.pbxproj
+++ b/slox.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		8755B8B42B91983F00530DC4 /* UserDefinedFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BAFC4A2B918C520013E5FE /* UserDefinedFunction.swift */; };
 		8755B8B52B91984C00530DC4 /* LoxCallable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BAFC482B9179CB0013E5FE /* LoxCallable.swift */; };
 		8764AB632BB8E5A7006D4B9D /* StandardLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792A9982BB36C66009842D8 /* StandardLibrary.swift */; };
+		8764AB652BC1FC9E006D4B9D /* ParameterList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8764AB642BC1FC9E006D4B9D /* ParameterList.swift */; };
+		8764AB662BC34B9A006D4B9D /* ParameterList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8764AB642BC1FC9E006D4B9D /* ParameterList.swift */; };
 		876560032B882259002BDE42 /* TokenType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876560022B882259002BDE42 /* TokenType.swift */; };
 		876560052B8825AC002BDE42 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876560042B8825AC002BDE42 /* Token.swift */; };
 		876560072B8827F9002BDE42 /* Scanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876560062B8827F9002BDE42 /* Scanner.swift */; };
@@ -96,6 +98,7 @@
 		873CCB2B2B8E88A500FC249A /* InterpreterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterpreterTests.swift; sourceTree = "<group>"; };
 		873CCB2F2B8EAEC100FC249A /* Statement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Statement.swift; sourceTree = "<group>"; };
 		873CCB322B8ED8B900FC249A /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		8764AB642BC1FC9E006D4B9D /* ParameterList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterList.swift; sourceTree = "<group>"; };
 		87655FF82B88210A002BDE42 /* slox */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = slox; sourceTree = BUILT_PRODUCTS_DIR; };
 		876560022B882259002BDE42 /* TokenType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenType.swift; sourceTree = "<group>"; };
 		876560042B8825AC002BDE42 /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
@@ -168,6 +171,7 @@
 				876A315E2B897EEB0085A350 /* LoxValue.swift */,
 				870230742B9571490056FE57 /* MutableCollection+Extension.swift */,
 				8732838E2B93F89300E49035 /* NativeFunction.swift */,
+				8764AB642BC1FC9E006D4B9D /* ParameterList.swift */,
 				876A31682B8C3AAB0085A350 /* ParseError.swift */,
 				876A31662B8C11810085A350 /* Parser.swift */,
 				873283912B95118A00E49035 /* ResolvedExpression.swift */,
@@ -313,6 +317,7 @@
 				8730DDE92BB250CE00372548 /* LoxDictionary.swift in Sources */,
 				870230752B9571490056FE57 /* MutableCollection+Extension.swift in Sources */,
 				873CCB252B8D765D00FC249A /* Lox.swift in Sources */,
+				8764AB652BC1FC9E006D4B9D /* ParameterList.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -320,6 +325,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8764AB662BC34B9A006D4B9D /* ParameterList.swift in Sources */,
 				8764AB632BB8E5A7006D4B9D /* StandardLibrary.swift in Sources */,
 				8702307C2B9575610056FE57 /* ResolvedStatement.swift in Sources */,
 				873CCB2D2B8E88C900FC249A /* Interpreter.swift in Sources */,

--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -14,7 +14,7 @@ indirect enum Expression: Equatable {
     case assignment(Token, Expression)
     case logical(Expression, Token, Expression)
     case call(Expression, Token, [Expression])
-    case lambda([Token]?, [Statement])
+    case lambda(ParameterList?, [Statement])
     case get(Expression, Token)
     case set(Expression, Token, Expression)
     case this(Token)

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -136,14 +136,11 @@ class Interpreter {
                 throw RuntimeError.notAFunctionDeclaration
             }
 
-            guard case .lambda(let paramTokens, let methodBody) = lambdaExpr else {
+            guard case .lambda(let parameterList, let methodBody) = lambdaExpr else {
                 throw RuntimeError.notALambda
             }
 
             let isInitializer = nameToken.lexeme == "init"
-            let parameterList = paramTokens.map { paramTokens in
-                ParameterList(normalParameters: paramTokens)
-            }
             let methodImpl = UserDefinedFunction(name: nameToken.lexeme,
                                                  parameterList: parameterList,
                                                  enclosingEnvironment: environment,
@@ -158,13 +155,10 @@ class Interpreter {
                 throw RuntimeError.notAFunctionDeclaration
             }
 
-            guard case .lambda(let paramTokens, let methodBody) = lambdaExpr else {
+            guard case .lambda(let parameterList, let methodBody) = lambdaExpr else {
                 throw RuntimeError.notALambda
             }
 
-            let parameterList = paramTokens.map { paramTokens in
-                ParameterList(normalParameters: paramTokens)
-            }
             let staticMethodImpl = UserDefinedFunction(name: nameToken.lexeme,
                                                        parameterList: parameterList,
                                                        enclosingEnvironment: environment,
@@ -192,14 +186,11 @@ class Interpreter {
     }
 
     private func handleFunctionDeclaration(name: Token, lambda: ResolvedExpression) throws {
-        guard case .lambda(let paramTokens, let body) = lambda else {
+        guard case .lambda(let parameterList, let body) = lambda else {
             throw RuntimeError.notALambda
         }
 
         let environmentWhenDeclared = self.environment
-        let parameterList = paramTokens.map { paramTokens in
-            ParameterList(normalParameters: paramTokens)
-        }
         let function = UserDefinedFunction(name: name.lexeme,
                                            parameterList: parameterList,
                                            enclosingEnvironment: environmentWhenDeclared,
@@ -314,8 +305,8 @@ class Interpreter {
                                            valueExpr: valueExpr)
         case .this(let thisToken, let depth):
             return try handleThis(thisToken: thisToken, depth: depth)
-        case .lambda(let params, let statements):
-            return try handleLambdaExpression(params: params, statements: statements)
+        case .lambda(let parameterList, let statements):
+            return try handleLambdaExpression(parameterList: parameterList, statements: statements)
         case .super(let superToken, let methodToken, let depth):
             return try handleSuperExpression(superToken: superToken, methodToken: methodToken, depth: depth)
         case .list(let elements):
@@ -533,12 +524,9 @@ class Interpreter {
         return try environment.getValueAtDepth(name: thisToken.lexeme, depth: depth)
     }
 
-    private func handleLambdaExpression(params: [Token]?, statements: [ResolvedStatement]) throws -> LoxValue {
+    private func handleLambdaExpression(parameterList: ParameterList?, statements: [ResolvedStatement]) throws -> LoxValue {
         let environmentWhenDeclared = self.environment
 
-        let parameterList = params.map { paramTokens in
-            ParameterList(normalParameters: paramTokens)
-        }
         let function = UserDefinedFunction(name: "lambda",
                                            parameterList: parameterList,
                                            enclosingEnvironment: environmentWhenDeclared,

--- a/slox/LoxCallable.swift
+++ b/slox/LoxCallable.swift
@@ -6,6 +6,6 @@
 //
 
 protocol LoxCallable {
-    var arity: Int { get }
+    var parameterList: ParameterList? { get }
     func call(interpreter: Interpreter, args: [LoxValue]) throws -> LoxValue
 }

--- a/slox/LoxClass.swift
+++ b/slox/LoxClass.swift
@@ -8,14 +8,8 @@
 class LoxClass: LoxInstance, LoxCallable {
     var name: String
     var superclass: LoxClass?
-    var arity: Int {
-        if let initializer = methods["init"] {
-            return initializer.arity
-        }
-
-        return 0
-    }
     var methods: [String: UserDefinedFunction]
+
     var instanceType: LoxInstance.Type {
         if self.name == "List" {
             LoxList.self
@@ -24,6 +18,14 @@ class LoxClass: LoxInstance, LoxCallable {
         } else {
             LoxInstance.self
         }
+    }
+
+    var parameterList: ParameterList? {
+        if let initializer = methods["init"] {
+            return initializer.parameterList
+        }
+
+        return ParameterList(normalParameters: [])
     }
 
     convenience init(name: String, superclass: LoxClass?, methods: [String: UserDefinedFunction]) {

--- a/slox/NativeFunction.swift
+++ b/slox/NativeFunction.swift
@@ -15,21 +15,27 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
     case keysNative
     case valuesNative
 
-    var arity: Int {
-        switch self {
+    var parameterList: ParameterList? {
+        let normalParameters: [String] = switch self {
         case .clock:
-            return 0
+            []
         case .appendNative:
-            return 2
+            ["this", "element"]
         case .deleteAtNative:
-            return 2
+            ["this", "index"]
         case .removeValueNative:
-            return 2
+            ["this", "index"]
         case .keysNative:
-            return 1
+            ["this"]
         case .valuesNative:
-            return 1
+            ["this"]
         }
+
+        return ParameterList(
+            normalParameters: normalParameters.map { paramName in
+                Token(type: .identifier, lexeme: paramName, line: 0)
+            }
+        )
     }
 
     func call(interpreter: Interpreter, args: [LoxValue]) throws -> LoxValue {

--- a/slox/ParameterList.swift
+++ b/slox/ParameterList.swift
@@ -1,0 +1,24 @@
+//
+//  ParameterList.swift
+//  slox
+//
+//  Created by Danielle Kefford on 4/6/24.
+//
+
+struct ParameterList: Equatable {
+    var normalParameters: [Token]
+    var variadicParameter: Token?
+
+    func checkArity(argCount: Int) throws {
+        let normalParameterCount = normalParameters.count
+        if let variadicParameter {
+            guard argCount >= normalParameterCount else {
+                throw RuntimeError.wrongArity(normalParameterCount, argCount)
+            }
+        }
+
+        guard argCount == normalParameterCount else {
+            throw RuntimeError.wrongArity(normalParameterCount, argCount)
+        }
+    }
+}

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -138,9 +138,9 @@ struct Parser {
             throw ParseError.missingFunctionName(currentToken)
         }
 
-        var parameters: [Token]? = nil
+        var parameterList: ParameterList? = nil
         if currentTokenMatchesAny(types: [.leftParen]) {
-            parameters = try parseParameters()
+            parameterList = try parseParameters()
             if !currentTokenMatchesAny(types: [.rightParen]) {
                 throw ParseError.missingCloseParenAfterArguments(currentToken)
             }
@@ -150,7 +150,7 @@ struct Parser {
             throw ParseError.missingOpenBraceBeforeFunctionBody(currentToken)
         }
 
-        return .function(functionName, .lambda(parameters, functionBody))
+        return .function(functionName, .lambda(parameterList, functionBody))
     }
 
     mutating private func parseVariableDeclaration() throws -> Statement? {
@@ -745,7 +745,7 @@ struct Parser {
     //    arguments      → expression ( "," expression )* ;
     //    kvPairs        → ( expression ":" expression ) ( expression ":" expression )* ;
     //
-    mutating private func parseParameters() throws -> [Token] {
+    mutating private func parseParameters() throws -> ParameterList {
         var parameters: [Token] = []
         if currentToken.type != .rightParen {
             repeat {
@@ -757,7 +757,8 @@ struct Parser {
             } while currentTokenMatchesAny(types: [.comma])
         }
 
-        return parameters
+        let parameterList = ParameterList(normalParameters: parameters)
+        return parameterList
     }
 
     mutating private func parseExpressionList(firstExpr: Expression) throws -> [Expression] {

--- a/slox/ResolvedExpression.swift
+++ b/slox/ResolvedExpression.swift
@@ -14,7 +14,7 @@ indirect enum ResolvedExpression: Equatable {
     case assignment(Token, ResolvedExpression, Int)
     case logical(ResolvedExpression, Token, ResolvedExpression)
     case call(ResolvedExpression, Token, [ResolvedExpression])
-    case lambda([Token]?, [ResolvedStatement])
+    case lambda(ParameterList?, [ResolvedStatement])
     case get(ResolvedExpression, Token)
     case set(ResolvedExpression, Token, ResolvedExpression)
     case this(Token, Int)

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -180,14 +180,14 @@ struct Resolver {
     mutating private func handleFunctionDeclaration(nameToken: Token,
                                                     lambdaExpr: Expression,
                                                     functionType: FunctionType) throws -> ResolvedStatement {
-        guard case .lambda(let paramTokens, let statements) = lambdaExpr else {
+        guard case .lambda(let parameterList, let statements) = lambdaExpr else {
             throw ResolverError.notAFunction
         }
 
         try declareVariable(name: nameToken.lexeme)
         defineVariable(name: nameToken.lexeme)
 
-        let resolvedLambda = try handleLambda(params: paramTokens,
+        let resolvedLambda = try handleLambda(parameterList: parameterList,
                                               statements: statements,
                                               functionType: functionType)
 
@@ -324,8 +324,8 @@ struct Resolver {
             return .grouping(resolvedExpr)
         case .logical(let leftExpr, let operToken, let rightExpr):
             return try handleLogical(leftExpr: leftExpr, operToken: operToken, rightExpr: rightExpr)
-        case .lambda(let params, let statements):
-            return try handleLambda(params: params, statements: statements, functionType: .lambda)
+        case .lambda(let parameterList, let statements):
+            return try handleLambda(parameterList: parameterList, statements: statements, functionType: .lambda)
         case .super(let superToken, let methodToken):
             return try handleSuper(superToken: superToken, methodToken: methodToken)
         case .list(let elements):
@@ -420,7 +420,7 @@ struct Resolver {
         return .logical(resolvedLeftExpr, operToken, resolvedRightExpr)
     }
 
-    mutating private func handleLambda(params: [Token]?,
+    mutating private func handleLambda(parameterList: ParameterList?,
                                        statements: [Statement],
                                        functionType: FunctionType) throws -> ResolvedExpression {
         beginScope()
@@ -434,8 +434,8 @@ struct Resolver {
             currentLoopType = previousLoopType
         }
 
-        if let params {
-            for param in params {
+        if let parameterList {
+            for param in parameterList.normalParameters {
                 try declareVariable(name: param.lexeme)
                 defineVariable(name: param.lexeme)
             }
@@ -447,7 +447,7 @@ struct Resolver {
             try resolve(statement: statement)
         }
 
-        return .lambda(params, resolvedStatements)
+        return .lambda(parameterList, resolvedStatements)
     }
 
     mutating private func handleSuper(superToken: Token, methodToken: Token) throws -> ResolvedExpression {

--- a/slox/UserDefinedFunction.swift
+++ b/slox/UserDefinedFunction.swift
@@ -9,29 +9,23 @@ import Foundation
 
 struct UserDefinedFunction: LoxCallable, Equatable {
     var name: String
-    var params: [Token]?
     var enclosingEnvironment: Environment
     var body: [ResolvedStatement]
     var isInitializer: Bool
-    var arity: Int {
-        if let params {
-            return params.count
-        } else {
-            return 0
-        }
-    }
-    var isComputedProperty: Bool {
-        return params == nil
-    }
     var objectId: UUID
+    var parameterList: ParameterList? = nil
+
+    var isComputedProperty: Bool {
+        return parameterList == nil
+    }
 
     init(name: String,
-         params: [Token]?,
+         parameterList: ParameterList?,
          enclosingEnvironment: Environment,
          body: [ResolvedStatement],
          isInitializer: Bool) {
         self.name = name
-        self.params = params
+        self.parameterList = parameterList
         self.enclosingEnvironment = enclosingEnvironment
         self.body = body
         self.isInitializer = isInitializer
@@ -41,9 +35,10 @@ struct UserDefinedFunction: LoxCallable, Equatable {
     func call(interpreter: Interpreter, args: [LoxValue]) throws -> LoxValue {
         let newEnvironment = Environment(enclosingEnvironment: enclosingEnvironment)
 
-        if let params {
+        if let parameterList {
             for (i, arg) in args.enumerated() {
-                newEnvironment.define(name: params[i].lexeme, value: arg)
+                let paramName = parameterList.normalParameters[i]
+                newEnvironment.define(name: paramName.lexeme, value: arg)
             }
         }
 
@@ -73,7 +68,7 @@ struct UserDefinedFunction: LoxCallable, Equatable {
         let newEnvironment = Environment(enclosingEnvironment: enclosingEnvironment)
         newEnvironment.define(name: "this", value: .instance(instance))
         return UserDefinedFunction(name: name,
-                                   params: params,
+                                   parameterList: parameterList,
                                    enclosingEnvironment: newEnvironment,
                                    body: body,
                                    isInitializer: isInitializer)

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -871,7 +871,7 @@ final class ParserTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "theAnswer", line: 1),
                 .lambda(
-                    [],
+                    ParameterList(normalParameters: []),
                     [
                         .print(.literal(.int(42)))
                     ])),
@@ -909,10 +909,10 @@ final class ParserTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "add", line: 1),
                 .lambda(
-                    [
+                    ParameterList(normalParameters: [
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
-                    ],
+                    ]),
                     [
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
@@ -978,10 +978,10 @@ final class ParserTests: XCTestCase {
         let expected: [Statement] = [
             .expression(
                 .lambda(
-                    [
+                    ParameterList(normalParameters: [
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
-                    ],
+                    ]),
                     [
                         .return(
                             Token(type: .return, lexeme: "return", line: 1),
@@ -1032,7 +1032,7 @@ final class ParserTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "sayName", line: 2),
                         .lambda(
-                            [],
+                            ParameterList(normalParameters: []),
                             [
                                 .print(
                                     .get(
@@ -1133,10 +1133,10 @@ final class ParserTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "add", line: 2),
                         .lambda(
-                            [
+                            ParameterList(normalParameters: [
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
-                            ],
+                            ]),
                             [
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
@@ -1194,9 +1194,9 @@ final class ParserTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "someMethod", line: 2),
                         .lambda(
-                            [
+                            ParameterList(normalParameters: [
                                 Token(type: .identifier, lexeme: "arg", line: 2)
-                            ],
+                            ]),
                             [
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -52,10 +52,10 @@ final class ResolverTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "add", line: 1),
                 .lambda(
-                    [
+                    ParameterList(normalParameters: [
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
-                    ],
+                    ]),
                     [
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
@@ -74,10 +74,10 @@ final class ResolverTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "add", line: 1),
                 .lambda(
-                    [
+                    ParameterList(normalParameters: [
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
-                    ],
+                    ]),
                     [
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
@@ -234,7 +234,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "sayName", line: 2),
                         .lambda(
-                            [],
+                            ParameterList(normalParameters: []),
                             [
                                 .print(
                                     .get(
@@ -255,7 +255,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "sayName", line: 2),
                         .lambda(
-                            [],
+                            ParameterList(normalParameters: []),
                             [
                                 .print(
                                     .get(
@@ -278,7 +278,7 @@ final class ResolverTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "foo", line: 1),
                 .lambda(
-                    [],
+                    ParameterList(normalParameters: []),
                     [
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
@@ -307,7 +307,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "init", line: 2),
                         .lambda(
-                            [],
+                            ParameterList(normalParameters: []),
                             [
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
@@ -339,10 +339,10 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "add", line: 2),
                         .lambda(
-                            [
+                            ParameterList(normalParameters: [
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
-                            ],
+                            ]),
                             [
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
@@ -365,10 +365,10 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "add", line: 2),
                         .lambda(
-                            [
+                            ParameterList(normalParameters: [
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
-                            ],
+                            ]),
                             [
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
@@ -401,7 +401,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "init", line: 2),
                         .lambda(
-                            [],
+                            ParameterList(normalParameters: []),
                             [
                                 .expression(
                                     .set(
@@ -449,7 +449,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "someMethod", line: 2),
                         .lambda(
-                            [],
+                            ParameterList(normalParameters: []),
                             [
                                 .expression(
                                     .call(
@@ -503,7 +503,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "foo", line: 2),
                         .lambda(
-                            [],
+                            ParameterList(normalParameters: []),
                             [
                                 .break(Token(type: .break, lexeme: "break", line: 3))
                             ])),


### PR DESCRIPTION
In this PR, we introduce a new `ParameterList` struct. This will ultimately house both a list of normal parameters as well as a single trailing variadic parameter, but for now will only be used for the former. Doing so takes a first step towards fully supporting variadic functions. The following additional changes were made:

* the `lambda` case for `Expression`s and `ResolvedExpression`s now has an optional `ParameterList` as an associated value instead of an optional list of `Token`s
* in the parser, `parseParameters()` now constructs and returns a `ParameterList`. It should be noted that `parseFunction()` will still initialize a `lambda` case with a nil value for `ParameterList` to preserve support for computed properties
* in the resolver, `handleLambda()` continues to declare and define variables, but this time by iterating over the parameter tokens inside the `ParameterList` instance it receives
* `LoxCallable` now has as part of its contract a computed property,`parameterList`, instead of `arity`. The three conforming objects, `NativeFunction`, `UserDefinedFunction`, and `LoxClass`, have been updated accordingly, but most notably, `NativeFunction` synthesizes `Token` instances with line number values set to `0` in order to return a `ParameterList` object.
* in the interpreter, functions and lambdas are created with the `ParameterList` instance passed in instead of `[Token]`, but it is in `handleCallExpression()` where the arity check is made significantly differently by calling `ParameterList.checkArity(argCount:)`, which will throw if the checkk fails. For the time being `ParameterList.checkArity(argCount:)` only examines normal parameters.