### PR TITLE
Implement variadic functions

### DIFF
--- a/slox/ParameterList.swift
+++ b/slox/ParameterList.swift
@@ -15,6 +15,8 @@ struct ParameterList: Equatable {
             guard argCount >= normalParameterCount else {
                 throw RuntimeError.wrongArity(normalParameterCount, argCount)
             }
+
+            return
         }
 
         guard argCount == normalParameterCount else {

--- a/slox/ParseError.swift
+++ b/slox/ParseError.swift
@@ -29,6 +29,7 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
     case missingParameterName(Token)
     case missingOpenBraceBeforeFunctionBody(Token)
     case missingCloseParenAfterArguments(Token)
+    case onlyOneTrailingVariadicParameterAllowed(Token)
     case missingIdentifierAfterDot(Token)
     case missingSuperclassName(Token)
     case missingDotAfterSuper(Token)
@@ -79,6 +80,8 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(token.line)] Error: expected open brace before function body"
         case .missingCloseParenAfterArguments(let token):
             return "[Line \(token.line)] Error: expected right parenthesis after arguments"
+        case .onlyOneTrailingVariadicParameterAllowed(let token):
+            return "[Line \(token.line)] Error: only one variadic parameter allowed at the end of parameter list"
         case .missingIdentifierAfterDot(let token):
             return "[Line \(token.line)] Error: expected identifer after dot"
         case .missingSuperclassName(let token):

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -439,6 +439,11 @@ struct Resolver {
                 try declareVariable(name: param.lexeme)
                 defineVariable(name: param.lexeme)
             }
+
+            if let variadicParameter = parameterList.variadicParameter {
+                try declareVariable(name: variadicParameter.lexeme)
+                defineVariable(name: variadicParameter.lexeme)
+            }
         } else if currentClassType == .none {
             throw ResolverError.functionsMustHaveAParameterList
         }

--- a/slox/UserDefinedFunction.swift
+++ b/slox/UserDefinedFunction.swift
@@ -36,9 +36,15 @@ struct UserDefinedFunction: LoxCallable, Equatable {
         let newEnvironment = Environment(enclosingEnvironment: enclosingEnvironment)
 
         if let parameterList {
-            for (i, arg) in args.enumerated() {
-                let paramName = parameterList.normalParameters[i]
-                newEnvironment.define(name: paramName.lexeme, value: arg)
+            for (i, parameter) in parameterList.normalParameters.enumerated() {
+                let arg = args[i]
+                newEnvironment.define(name: parameter.lexeme, value: arg)
+            }
+
+            if let variadicParameter = parameterList.variadicParameter {
+                let varArgs = Array(args[parameterList.normalParameters.count...])
+                let varArgsList = try interpreter.makeList(elements: varArgs)
+                newEnvironment.define(name: variadicParameter.lexeme, value: varArgsList)
             }
         }
 

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -286,6 +286,20 @@ a
         }
     }
 
+    func testInterpretVariadicFunction() throws {
+        let input = """
+fun avg(*nums) {
+    return nums.reduce(0, fun(acc, num) { return acc+num; })/nums.count;
+}
+avg(1, 2, 3, 4, 5)
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .int(3)
+        XCTAssertEqual(actual, expected)
+    }
+
     func testInterpretClassDeclarationAndInstantiation() throws {
         let input = """
 class Person {}


### PR DESCRIPTION
This implementation supports a _single_ trailing variadic parameter, with that parameter designated as such by being preceded by an asterisk. Below is an example:

```
fun foo(a, *b) {
    return b.count;
}
```

The following changes were made:

* If there are any other parameters that follow a variadic parameter, the parser will throw `ParseError.onlyOneTrailingVariadicParameterAllowed`. Otherwise, the parser will set the token associated with the variadic parameter in `ParameterList` in the AST. 
* The changes for the resolver were fairly straightforward, resolving the variadic parameter if it exists.
* `UserDefinedFunction.call()` can now evaluate _both_ the regular and variadic parameters. If the latter exists, the list of  arguments following those associated with regular parameters are put into a Lox list and defined in the environment as the value associated with the variadic parameter name.

I also fixed a subtle but significant bug in `ParameterList.checkArity(argCount:)`: there needs to be an explicit return in the case where there is a variadic parameter, rather than falling through to the next `guard` statement and potentially wrongly throwing an error.