### PR TITLE
Implement splat operator

### DIFF
--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -23,6 +23,7 @@ indirect enum Expression: Equatable {
     case subscriptGet(Expression, Expression)
     case subscriptSet(Expression, Expression, Expression)
     case dictionary([(Expression, Expression)])
+    case splat(Expression)
 
     static func == (lhs: Expression, rhs: Expression) -> Bool {
         switch (lhs, rhs) {

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -562,8 +562,17 @@ class Interpreter {
     }
 
     private func handleListExpression(elements: [ResolvedExpression]) throws -> LoxValue {
-        let elementValues = try elements.map { element in
-            return try evaluate(expr: element)
+        var elementValues: [LoxValue] = []
+        for element in elements {
+            if case .splat = element {
+                guard case .instance(let list as LoxList) = try evaluate(expr: element) else {
+                    throw RuntimeError.notAList
+                }
+                elementValues.append(contentsOf: list.elements)
+            } else {
+                let elementValue = try evaluate(expr: element)
+                elementValues.append(elementValue)
+            }
         }
 
         return try makeList(elements: elementValues)

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -405,7 +405,7 @@ struct Parser {
     //    comparison     → term ( ( ">" | ">=" | "<" | "<=" ) term )* ;
     //    term           → factor ( ( "-" | "+" ) factor )* ;
     //    factor         → unary ( ( "/" | "*" | "%" ) unary )* ;
-    //    unary          → ( "!" | "-" ) unary
+    //    unary          → ( "!" | "-" | "*" ) unary
     //                   | postfix ;
     //    postfix        → primary ( "(" arguments? ")" | "." IDENTIFIER | "[" logicOr "]" )* ;
     //    primary        → NUMBER | STRING | "true" | "false" | "nil"
@@ -539,6 +539,11 @@ struct Parser {
             let oper = previousToken
             let expr = try parseUnary()
             return .unary(oper, expr)
+        }
+
+        if currentTokenMatchesAny(types: [.star]) {
+            let expr = try parseUnary()
+            return .splat(expr)
         }
 
         return try parsePostfix()

--- a/slox/ResolvedExpression.swift
+++ b/slox/ResolvedExpression.swift
@@ -23,6 +23,7 @@ indirect enum ResolvedExpression: Equatable {
     case subscriptGet(ResolvedExpression, ResolvedExpression)
     case subscriptSet(ResolvedExpression, ResolvedExpression, ResolvedExpression)
     case dictionary([(ResolvedExpression, ResolvedExpression)])
+    case splat(ResolvedExpression)
 
     static func == (lhs: ResolvedExpression, rhs: ResolvedExpression) -> Bool {
         switch (lhs, rhs) {

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -334,6 +334,8 @@ struct Resolver {
             return try handleSubscriptGet(listExpr: listExpr, indexExpr: indexExpr)
         case .subscriptSet(let listExpr, let indexExpr, let valueExpr):
             return try handleSubscriptSet(listExpr: listExpr, indexExpr: indexExpr, valueExpr: valueExpr)
+        case .splat(let listExpr):
+            return try handleSplat(listExpr: listExpr)
         case .dictionary(let kvPairs):
             return try handleDictionary(kvPairs: kvPairs)
         }
@@ -492,6 +494,12 @@ struct Resolver {
         let resolvedValueExpr = try resolve(expression: valueExpr)
 
         return .subscriptSet(resolvedListExpr, resolvedIndexExpr, resolvedValueExpr)
+    }
+
+    mutating private func handleSplat(listExpr: Expression) throws -> ResolvedExpression {
+        let resolvedListExpr = try resolve(expression: listExpr)
+
+        return .splat(resolvedListExpr)
     }
 
     mutating private func handleDictionary(kvPairs: [(Expression, Expression)]) throws -> ResolvedExpression {

--- a/slox/ResolverError.swift
+++ b/slox/ResolverError.swift
@@ -21,6 +21,7 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
     case cannotBreakOutsideLoop
     case cannotContinueOutsideLoop
     case functionsMustHaveAParameterList
+    case cannotUseSplatOperatorOutOfContext
 
     var description: String {
         switch self {
@@ -50,6 +51,8 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
             return "Can only `continue` from inside a `while` or `for` loop"
         case .functionsMustHaveAParameterList:
             return "Functions must have a parameter list"
+        case .cannotUseSplatOperatorOutOfContext:
+            return "Cannot use splat operator in this context"
         }
     }
 }

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -300,6 +300,37 @@ avg(1, 2, 3, 4, 5)
         XCTAssertEqual(actual, expected)
     }
 
+    func testInterpretSplattingIntoAnArgumentList() throws {
+        let input =  """
+var foo = [1, 2, 3];
+fun sum(a, b, c) {
+    return a+b+c;
+}
+sum(*foo)
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .int(6)
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretSplattingWorksProperlyWithArityChecker() throws {
+        let input =  """
+fun sum(a, b, c) {
+    return a+b+c;
+}
+var foo = [1, 2, 3];
+sum(*foo, 4, 5)
+"""
+
+        let interpreter = Interpreter()
+        let expectedError = RuntimeError.wrongArity(3, 5)
+        XCTAssertThrowsError(try interpreter.interpretRepl(source: input)!) { actualError in
+            XCTAssertEqual(actualError as! RuntimeError, expectedError)
+        }
+    }
+
     func testInterpretClassDeclarationAndInstantiation() throws {
         let input = """
 class Person {}
@@ -721,6 +752,25 @@ foo.reduce(0, fun(acc, n) { return acc+n; })
         let interpreter = Interpreter()
         let actual = try interpreter.interpretRepl(source: input)
         let expected: LoxValue = .int(15)
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretSplattingAListIntoAnotherList() throws {
+        let input = """
+var foo = [1, 2, 3];
+[*foo, 4, 5, 6]
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected = try interpreter.makeList(elements: [
+            .int(1),
+            .int(2),
+            .int(3),
+            .int(4),
+            .int(5),
+            .int(6),
+        ])
         XCTAssertEqual(actual, expected)
     }
 

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -1064,6 +1064,41 @@ final class ParserTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    func testParseFunctionCallWithSplattedArgument() throws {
+        // add(*[1, 2, 3])
+        let tokens: [Token] = [
+            Token(type: .identifier, lexeme: "add", line: 1),
+            Token(type: .leftParen, lexeme: "(", line: 1),
+            Token(type: .star, lexeme: "*", line: 1),
+            Token(type: .leftBracket, lexeme: "[", line: 1),
+            Token(type: .int, lexeme: "1", line: 1),
+            Token(type: .comma, lexeme: ",", line: 1),
+            Token(type: .int, lexeme: "2", line: 1),
+            Token(type: .comma, lexeme: ",", line: 1),
+            Token(type: .int, lexeme: "3", line: 1),
+            Token(type: .rightBracket, lexeme: "]", line: 1),
+            Token(type: .rightParen, lexeme: ")", line: 1),
+            Token(type: .eof, lexeme: "", line: 1),
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let actual = try parser.parse()
+        let expected: [Statement] = [
+            .expression(
+                .call(
+                    .variable(Token(type: .identifier, lexeme: "add", line: 1)),
+                    Token(type: .rightParen, lexeme: ")", line: 1),
+                    [
+                        .splat(
+                            .list([
+                                .literal(.int(1)),
+                                .literal(.int(2)),
+                                .literal(.int(3)),
+                            ]))
+                    ])),
+        ]
+    }
+
     func testParseLambdaExpression() throws {
         // fun (a, b) { return a + b; }
         let tokens: [Token] = [

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -521,4 +521,23 @@ final class ResolverTests: XCTestCase {
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
     }
+
+    func testResolveTopLevelExpressionWithSplatOperator() throws {
+        // *[1, 2, 3]
+        let statements: [Statement] = [
+            .expression(
+                .splat(
+                    .list([
+                        .literal(.int(1)),
+                        .literal(.int(2)),
+                        .literal(.int(3)),
+                    ])))
+        ]
+
+        var resolver = Resolver()
+        let expectedError = ResolverError.cannotUseSplatOperatorOutOfContext
+        XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
+            XCTAssertEqual(actualError as! ResolverError, expectedError)
+        }
+    }
 }


### PR DESCRIPTION
This PR allows for the so-called splatting of lists into either argument lists or list literals using the `*` operator that is similar to how languages like Ruby accomplish the same. Below are two example use cases:

```
fun sum(a, b, c) {
    return a + b + c;
}
var foo = [1, 2, 3]
sum(*foo) // Results in the number 6

[*foo, 4, 5, 6] // Results in the list [1, 2, 3, 4, 5, 6]
```

The following changes were made in support of this endeavor:

* Introduced new `splat` case in `Expression` (and `ResolvedExpression`). At the point of parsing, we are not able to evaluate list values and splat them in. And so we need to capture the intent of the programmer in the AST itself so that when we _are_ in the interpreter and able to evaluate expressions, we can do the right thing.
* Updated grammar rules in the parser by adding logic in `parseUnary()` to return `.splat(expr)` if it encounters an asterisk preceding an expression.
* Introduced new enum, `ArgumentListType`, in the resolver so that we can check if a splatted value makes sense in a given context. For example, evaluating `*[1, 2, 3]` at the top level makes no sense because there is nothing to splat the list into, and the resolver will throw and error, `ResolverError.cannotUseSplatOperatorOutOfContext`. Currently, only argument lists and list literals allow for splatting.
* In the interpreter, we need a new handler, `handleSplatExpression()` with simply returns the list evaluated, as well as updated logic in `handleListExpression()` and `handleCallExpression()` to splat in any list values they encounter. It should be noted that the arity check in `handleCallExpression()` now needs to be done _after_ calling `evaluateAndFlatten()` because we don't know how many arguments there will be beforehand.
