### PR TITLE
`this` not being properly resolved for subclasses

### DIFF
--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -418,7 +418,7 @@ struct Resolver {
     }
 
     mutating private func handleThis(thisToken: Token) throws -> ResolvedExpression {
-        guard case .class = currentClassType else {
+        guard currentClassType != .none else {
             throw ResolverError.cannotReferenceThisOutsideClass
         }
 

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -395,6 +395,34 @@ me.greeting()
         XCTAssertEqual(actual, expected)
     }
 
+    func testInterpretMethodInSubclassWithThisReferenceResolves() throws {
+        let input = """
+class A {
+    init(foo) {
+        this.foo = foo;
+    }
+}
+
+class B < A {
+    init(foo) {
+        super.init(foo);
+    }
+
+    getFoo() {
+        return this.foo;
+    }
+}
+
+var b = B(42);
+b.getFoo()
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .int(42)
+        XCTAssertEqual(actual, expected)
+    }
+
     func testInterpretInstancePropertyHasNotYetBeenSet() throws {
         let input = """
 class Person {}


### PR DESCRIPTION
Previously, when resolving `this` in `handleThis()`, I only considered the case when the current class type was `class` and not `subclass` as well. This PR fixes that problem, as well as includes a guarding unit test.