### PR TITLE
Improve code in `Scanner`

### DIFF
--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -71,6 +71,8 @@ indirect enum Expression: Equatable {
             }
 
             return true
+        case (.splat(let lhsList), .splat(let rhsList)):
+            return lhsList == rhsList
         default:
             return false
         }

--- a/slox/ResolvedExpression.swift
+++ b/slox/ResolvedExpression.swift
@@ -71,6 +71,8 @@ indirect enum ResolvedExpression: Equatable {
             }
 
             return true
+        case (.splat(let lhsList), .splat(let rhsList)):
+            return lhsList == rhsList
         default:
             return false
         }

--- a/slox/Scanner.swift
+++ b/slox/Scanner.swift
@@ -11,9 +11,6 @@ struct Scanner {
 
     private var startIndex: String.Index
     private var currentIndex: String.Index
-    private var nextIndex: String.Index {
-        return source.index(after: currentIndex)
-    }
     private var line = 1
 
     let keywords: [String: TokenType] = [
@@ -55,70 +52,128 @@ struct Scanner {
         return tokens
     }
 
-    mutating private func scanToken() throws {
-        switch source[currentIndex] {
-        // One character lexemes
-        case "(":
-            handleSingleCharacterLexeme(type: .leftParen)
-        case ")":
-            handleSingleCharacterLexeme(type: .rightParen)
-        case "{":
-            handleSingleCharacterLexeme(type: .leftBrace)
-        case "}":
-            handleSingleCharacterLexeme(type: .rightBrace)
-        case "[":
-            handleSingleCharacterLexeme(type: .leftBracket)
-        case "]":
-            handleSingleCharacterLexeme(type: .rightBracket)
-        case ",":
-            handleSingleCharacterLexeme(type: .comma)
-        case ".":
-            handleSingleCharacterLexeme(type: .dot)
-        case ";":
-            handleSingleCharacterLexeme(type: .semicolon)
-        case "%":
-            handleSingleCharacterLexeme(type: .modulus)
-        case ":":
-            handleSingleCharacterLexeme(type: .colon)
-        case "/":
-            handleSlash()
+    var scannedToken: String {
+        String(source[startIndex..<currentIndex])
+    }
 
-        // Lexemes that can be one or two characters
-        case "!":
-            handleOneOrTwoCharacterLexeme(oneCharLexeme: .bang, twoCharLexeme: .bangEqual)
-        case "=":
-            handleOneOrTwoCharacterLexeme(oneCharLexeme: .equal, twoCharLexeme: .equalEqual)
-        case "<":
-            handleOneOrTwoCharacterLexeme(oneCharLexeme: .less, twoCharLexeme: .lessEqual)
-        case ">":
-            handleOneOrTwoCharacterLexeme(oneCharLexeme: .greater, twoCharLexeme: .greaterEqual)
-        case "-":
-            handleOneOrTwoCharacterLexeme(oneCharLexeme: .minus, twoCharLexeme: .minusEqual)
-        case "+":
-            handleOneOrTwoCharacterLexeme(oneCharLexeme: .plus, twoCharLexeme: .plusEqual)
-        case "*":
-            handleOneOrTwoCharacterLexeme(oneCharLexeme: .star, twoCharLexeme: .starEqual)
-
-        // Whitespace
-        case " ", "\r", "\t":
-            break
-        case "\n":
-            line += 1
-
-        case "\"":
-            try handleString()
-
-        case "0"..."9":
-            handleNumber()
-
-        case "a"..."z", "A"..."Z":
-            handleIdentifier()
-
-        default:
-            throw ScanError.unexpectedCharacter(line)
+    mutating private func tryScan(where predicate: (Character) -> Bool) -> Bool {
+        guard currentIndex < source.endIndex && predicate(source[currentIndex]) else {
+            return false
         }
 
-        advanceCursor()
+        currentIndex = source.index(after: currentIndex)
+        return true
+    }
+
+    mutating private func tryScan(_ charRanges: ClosedRange<Character>...) -> Bool {
+        tryScan(where: { char in
+            charRanges.contains(where: { charRange in
+                charRange.contains(char)
+            })
+        })
+    }
+
+    mutating private func tryNotScan(_ char: Character) -> Bool {
+        tryScan(where: { actualChar in
+            actualChar != char
+        })
+    }
+
+    mutating private func tryScan(_ chars: Character...) -> Bool {
+        tryScan(where: chars.contains(_:))
+    }
+
+    private func repeatedly(_ tryScanFn: () -> Bool) {
+        var scanned: Bool
+        repeat {
+            scanned = tryScanFn()
+        } while scanned
+    }
+
+    mutating private func scanToken() throws {
+        // One character lexemes
+        if tryScan("(") {
+            handleSingleCharacterLexeme(type: .leftParen)
+        }
+        else if tryScan(")") {
+            handleSingleCharacterLexeme(type: .rightParen)
+        }
+        else if tryScan("{") {
+            handleSingleCharacterLexeme(type: .leftBrace)
+        }
+        else if tryScan("}") {
+            handleSingleCharacterLexeme(type: .rightBrace)
+        }
+        else if tryScan("[") {
+            handleSingleCharacterLexeme(type: .leftBracket)
+        }
+        else if tryScan("]") {
+            handleSingleCharacterLexeme(type: .rightBracket)
+        }
+        else if tryScan(",") {
+            handleSingleCharacterLexeme(type: .comma)
+        }
+        else if tryScan(".") {
+            handleSingleCharacterLexeme(type: .dot)
+        }
+        else if tryScan(";") {
+            handleSingleCharacterLexeme(type: .semicolon)
+        }
+        else if tryScan("%") {
+            handleSingleCharacterLexeme(type: .modulus)
+        }
+        else if tryScan(":") {
+            handleSingleCharacterLexeme(type: .colon)
+        }
+        else if tryScan("/") {
+            handleSlash()
+        }
+
+        // Lexemes that can be one or two characters
+        else if tryScan("!") {
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .bang, twoCharLexeme: .bangEqual)
+        }
+        else if tryScan("=") {
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .equal, twoCharLexeme: .equalEqual)
+        }
+        else if tryScan("<") {
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .less, twoCharLexeme: .lessEqual)
+        }
+        else if tryScan(">") {
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .greater, twoCharLexeme: .greaterEqual)
+        }
+        else if tryScan("-") {
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .minus, twoCharLexeme: .minusEqual)
+        }
+        else if tryScan("+") {
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .plus, twoCharLexeme: .plusEqual)
+        }
+        else if tryScan("*") {
+            handleOneOrTwoCharacterLexeme(oneCharLexeme: .star, twoCharLexeme: .starEqual)
+        }
+
+        // Whitespace
+        else if tryScan(" ", "\r", "\t") {
+            // do nothing
+        }
+        else if tryScan("\n") {
+            line += 1
+        }
+
+        else if tryScan("\"") {
+            try handleString()
+        }
+
+        else if tryScan("0"..."9") {
+            handleNumber()
+        }
+
+        else if tryScan("a"..."z", "A"..."Z") {
+            handleIdentifier()
+        }
+        else {
+            throw ScanError.unexpectedCharacter(line)
+        }
     }
 
     mutating private func handleSingleCharacterLexeme(type: TokenType) {
@@ -126,20 +181,15 @@ struct Scanner {
     }
 
     mutating private func handleSlash() {
-        if nextIndex < source.endIndex,
-           source[nextIndex] == "/" {
-            while nextIndex < source.endIndex,
-                  source[nextIndex] != "\n" {
-                advanceCursor()
-            }
+        if tryScan("/") {
+            repeatedly { tryNotScan("\n") }
         } else {
             handleOneOrTwoCharacterLexeme(oneCharLexeme: .slash, twoCharLexeme: .slashEqual)
         }
     }
 
     mutating private func handleOneOrTwoCharacterLexeme(oneCharLexeme: TokenType, twoCharLexeme: TokenType) {
-        if nextIndex < source.endIndex, source[nextIndex] == "=" {
-            advanceCursor()
+        if tryScan("=") {
             addToken(type: twoCharLexeme)
         } else {
             addToken(type: oneCharLexeme)
@@ -147,13 +197,9 @@ struct Scanner {
     }
 
     mutating private func handleString() throws {
-        advanceCursor()
-        while currentIndex < source.endIndex,
-              source[currentIndex] != "\"" {
-            advanceCursor()
-        }
+        repeatedly { tryNotScan("\"") }
 
-        if currentIndex == source.endIndex {
+        guard tryScan("\"") else {
             throw ScanError.unterminatedString(line)
         }
 
@@ -161,47 +207,30 @@ struct Scanner {
     }
 
     mutating private func handleNumber() {
-        while nextIndex < source.endIndex,
-              source[nextIndex].isNumber {
-            advanceCursor()
-        }
+        repeatedly { tryScan(where: \.isNumber) }
 
         var tokenType: TokenType = .int
-        if nextIndex < source.endIndex,
-           source[nextIndex] == "." {
+        if tryScan(".") {
             tokenType = .double
-            advanceCursor()
 
-            while nextIndex < source.endIndex,
-                  source[nextIndex].isNumber {
-                advanceCursor()
-            }
+            repeatedly { tryScan(where: \.isNumber) }
         }
 
         addToken(type: tokenType)
     }
 
     mutating private func handleIdentifier() {
-        while nextIndex < source.endIndex &&
-                (source[nextIndex].isLetter ||
-                 source[nextIndex].isNumber ||
-                 source[nextIndex] == "_") {
-            advanceCursor()
-        }
+        repeatedly { tryScan(where: { $0.isLetter || $0.isNumber || $0 == "_" }) }
 
-        if let type = keywords[String(source[startIndex...currentIndex])] {
+        if let type = keywords[scannedToken] {
             addToken(type: type)
         } else {
             addToken(type: .identifier)
         }
     }
 
-    mutating private func advanceCursor() {
-        currentIndex = source.index(after: currentIndex)
-    }
-
     mutating private func addToken(type: TokenType) {
-        let text = String(source[startIndex...currentIndex])
+        let text = scannedToken
         let newToken = Token(type: type, lexeme: text, line: line)
         tokens.append(newToken)
     }

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -1094,9 +1094,10 @@ final class ParserTests: XCTestCase {
                                 .literal(.int(1)),
                                 .literal(.int(2)),
                                 .literal(.int(3)),
-                            ]))
+                            ])),
                     ])),
         ]
+        XCTAssertEqual(actual, expected)
     }
 
     func testParseLambdaExpression() throws {


### PR DESCRIPTION
Inspired by a post that I saw on Mastodon, and after talking to my girlfriend about it, I decided to take the plunge and refactor `Scanner`. (I should note that most of the code for this PR was written by my girlfriend. 😅). The main thrust of this PR is to:

* centralize string index management, namely the advancement of the cursor (the index into the string pointing to the end of the token currently being scanned), rather than having bits of that logic sprinkled across all of the token handlers.
* reduce code duplication

There are now several `tryScan()` methods, and a `tryNotScan()` method, which accomplish both of the above, as well as a `repeatedly()` method to avoid having `while` loops proliferating about the file. 

Also, there was a bug hidden in the scanner by using `Character.isDigit`, which includes a bunch of Unicode characters outside of the ASCII digit range, and would have resulted in a crash if the user used one of them. Hence, we introduced and now use `Character.isLoxDigit` when scanning numbers.

Also, there was a tiny problem in the unit test suite, not in the functionality of the parser itself, where there was a missing assertion, which revealed a missing case in the `==` method for `Expression` and `ResolvedExpression`.