### PR TITLE
Whoops! `isLoxDigit()` is wrong!

### DIFF
--- a/slox/Scanner.swift
+++ b/slox/Scanner.swift
@@ -209,6 +209,6 @@ struct Scanner {
 
 extension Character {
     var isLoxDigit: Bool {
-        ("0"..."9").contains(self)
+        return self.isASCII && self.isNumber
     }
 }

--- a/sloxTests/ScannerTests.swift
+++ b/sloxTests/ScannerTests.swift
@@ -102,6 +102,15 @@ final class ScannerTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    func testScanningOfEmojiNumbersResultsInError() throws {
+        let source = "1️⃣"
+        var scanner = Scanner(source: source)
+        let expectedError = ScanError.unexpectedCharacter(1)
+        XCTAssertThrowsError(try scanner.scanTokens()) { actualError in
+            XCTAssertEqual(actualError as! ScanError, expectedError)
+        }
+    }
+
     func testScanningOfKeywords() throws {
         let source = "and class else false for fun if nil or print return super this true var while break continue"
         var scanner = Scanner(source: source)


### PR DESCRIPTION
So... originally I had the following check in `Character.isLoxDigit`:

```
("0"..."9").contains(self)
```

... but that doesn't work for the following reason:

![image](https://github.com/quephird/slox/assets/352416/a19b563f-d8b5-43dc-8a56-314b62dcc233)

So... I deferred to the advice given here, https://stackoverflow.com/a/26353225
