### PR TITLE
Expose `getInput()`

### DIFF
--- a/slox/Lox.swift
+++ b/slox/Lox.swift
@@ -43,7 +43,7 @@ struct Lox {
         while let input = readLine() {
             do {
                 if let result = try interpreter.interpretRepl(source: input) {
-                    print(result)
+                    print(String(reflecting: result))
                 }
             } catch {
                 print(error)

--- a/slox/LoxValue.swift
+++ b/slox/LoxValue.swift
@@ -5,7 +5,7 @@
 //  Created by Danielle Kefford on 2/23/24.
 //
 
-enum LoxValue: CustomStringConvertible, Equatable, Hashable {
+enum LoxValue: CustomStringConvertible, CustomDebugStringConvertible, Equatable, Hashable {
     case string(String)
     case double(Double)
     case int(Int)
@@ -16,6 +16,15 @@ enum LoxValue: CustomStringConvertible, Equatable, Hashable {
     case instance(LoxInstance)
 
     var description: String {
+        switch self {
+        case .string(let string):
+            return string
+        default:
+            return self.debugDescription
+        }
+    }
+
+    var debugDescription: String {
         switch self {
         case .string(let string):
             return "\"\(string)\""
@@ -39,7 +48,7 @@ enum LoxValue: CustomStringConvertible, Equatable, Hashable {
                 if i > 0 {
                     string.append(", ")
                 }
-                string.append("\(element)")
+                string.append("\(String(reflecting: element))")
             }
             string.append("]")
             return string
@@ -53,7 +62,7 @@ enum LoxValue: CustomStringConvertible, Equatable, Hashable {
                         string.append(", ")
                     }
                     let (key, value) = kvPair
-                    string.append("\(key): \(value)")
+                    string.append("\(String(reflecting: key)): \(String(reflecting: value))")
                 }
             }
             string.append("]")

--- a/slox/NativeFunction.swift
+++ b/slox/NativeFunction.swift
@@ -9,7 +9,9 @@ import Foundation
 
 enum NativeFunction: LoxCallable, Equatable, CaseIterable {
     case clock
-    case getInputNative
+    case toInt
+    case toDouble
+    case getInput
     case appendNative
     case deleteAtNative
     case removeValueNative
@@ -20,7 +22,11 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
         let normalParameters: [String] = switch self {
         case .clock:
             []
-        case .getInputNative:
+        case .toInt:
+            ["input"]
+        case .toDouble:
+            ["input"]
+        case .getInput:
             ["prompt"]
         case .appendNative:
             ["this", "element"]
@@ -45,7 +51,27 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
         switch self {
         case .clock:
             return .double(Date().timeIntervalSince1970)
-        case .getInputNative:
+        case .toInt:
+            guard case .string(let string) = args[0] else {
+                throw RuntimeError.notAString
+            }
+
+            if let integer = Int(string) {
+                return .int(integer)
+            }
+
+            return .nil
+        case .toDouble:
+            guard case .string(let string) = args[0] else {
+                throw RuntimeError.notAString
+            }
+
+            if let double = Double(string) {
+                return .double(double)
+            }
+
+            return .nil
+        case .getInput:
             let prompt = args[0]
             print(prompt, terminator: " ")
             if let input = readLine() {

--- a/slox/NativeFunction.swift
+++ b/slox/NativeFunction.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum NativeFunction: LoxCallable, Equatable, CaseIterable {
     case clock
+    case getInputNative
     case appendNative
     case deleteAtNative
     case removeValueNative
@@ -19,6 +20,8 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
         let normalParameters: [String] = switch self {
         case .clock:
             []
+        case .getInputNative:
+            ["prompt"]
         case .appendNative:
             ["this", "element"]
         case .deleteAtNative:
@@ -42,6 +45,14 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
         switch self {
         case .clock:
             return .double(Date().timeIntervalSince1970)
+        case .getInputNative:
+            let prompt = args[0]
+            print(prompt, terminator: " ")
+            if let input = readLine() {
+                return .string(input)
+            }
+
+            return .nil
         case .appendNative:
             guard case .instance(let loxList as LoxList) = args[0] else {
                 throw RuntimeError.notAList

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -21,6 +21,7 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case notADictionary
     case notAListOrDictionary
     case notANumber
+    case notAString
     case onlyInstancesHaveProperties
     case undefinedProperty(String)
     case wrongArity(Int, Int)
@@ -57,6 +58,8 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "Error: expected a list or dictionary"
         case .notANumber:
             return "Error: expected a number"
+        case .notAString:
+            return "Error: expected a string"
         case .onlyInstancesHaveProperties:
             return "Error: can only get/set properties of instances"
         case .undefinedProperty(let name):

--- a/slox/StandardLibrary.swift
+++ b/slox/StandardLibrary.swift
@@ -6,10 +6,6 @@
 //
 
 let standardLibrary = """
-fun getInput(prompt) {
-    return getInputNative(prompt);
-}
-
 class List {
     clone() {
         return this + [];

--- a/slox/StandardLibrary.swift
+++ b/slox/StandardLibrary.swift
@@ -6,6 +6,10 @@
 //
 
 let standardLibrary = """
+fun getInput(prompt) {
+    return getInputNative(prompt);
+}
+
 class List {
     clone() {
         return this + [];


### PR DESCRIPTION
This PR is fairly straightforward in exposing a new top-level `getInput()` function for getting user input with a prompt, and also two methods, `toInt()`, and `toDouble()` to be able to convert strings to ints and doubles, respectively. 

But it also includes some subtle but significant changes to `LoxValue`, namely that there is now a conformance to `CustomDebugStringConvertible`. This is necessary because there needs to be _two_ ways of printing `LoxValue`s, specifically string values: one for showing the internal representation of a value, and the other which is intended to be shown to a user. In the former case, we _do_ want quotation marks to differentiate strings from other scalar values, namely in the REPL; however, in the latter case, we do _not_ want to display quotation marks, only the raw string itself, as when we print strings in the context of a running program.