### PR TITLE
Introduce enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ enum Color {
 }
 
 var randomColor = Color.choose();
-print randomColor.name
+randomColor.name         // Prints one of "red", "green", or "blue"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,60 @@ var sa = SavingsAccount(199);
 sa.withdraw(100);
 ```
 
+### Enums
+
+slox also supports enums:
+
+```
+enum Color {
+    case red, green, blue;
+}
+```
+
+All enum cases have a `name` property, and all enums have an `allCases` computed property which returns a list of all the defined cases:
+
+```
+Color.red.name           // Prints "red"
+Color.allCases           // Prints [<enum case: Color.red>,
+                         //         <enum case: Color.green>,
+                         //         <enum case: Color.blue>]
+```
+
+You can define methods on them too, as well as computed properties. Specific enum cases are referred to by the `this` keyword, similarly to how class instances are:
+
+```
+enum Color {
+    case red, green, blue;
+
+    isRed() {
+        if (this == Color.red) {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+Color.green.isRed()      // Prints "false"
+```
+
+As with Lox classes, static methods are declared inside an enum using the `class` keyword:
+
+```
+enum Color {
+    case red, green, blue;
+
+    class choose() {
+        var cases = Color.allCases;
+        return cases[randInt(0, cases.count-1)];
+    }
+}
+
+var randomColor = Color.choose();
+print randomColor.name
+```
+
+
 ### Collections
 
 Currently, there are two collection types supported in slox: lists and dictionaries. List literals are created using square brackets, and there are native properties and functions for them:

--- a/examples/wordle.lox
+++ b/examples/wordle.lox
@@ -8,18 +8,20 @@ var blackForeground = esc + "[30m";
 var reset = esc + "[0m";
 var clearScreen = esc + "[2J";
 
-// Letter statuses
-var notGuessed = 0;
-var correctPosition = 1;
-var wrongPosition = 2;
-var noMatch = 3;
+enum LetterStatus {
+    notGuessed,
+    correctPosition,
+    wrongPosition,
+    noMatch
+}
 
-// Game statuses
-var win = 0;
-var loss = 1;
-var invalidGuess = 2;
-var wordNotInList = 3;
-var stillGoing = 4;
+enum GameStatus {
+    win,
+    loss,
+    invalidGuess,
+    wordNotInList,
+    stillGoing
+}
 
 class WordList {
     init() {
@@ -276,11 +278,11 @@ class Letter {
     format() {
         var backgroundColor = nil;
 
-        if (this.status == correctPosition) {
+        if (this.status == LetterStatus.correctPosition) {
             backgroundColor = greenBackground;
-        } else if (this.status == wrongPosition) {
+        } else if (this.status == LetterStatus.wrongPosition) {
             backgroundColor = yellowBackground;
-        } else if (this.status == noMatch) {
+        } else if (this.status == LetterStatus.noMatch) {
             backgroundColor = greyBackground;
         } else {
             backgroundColor = whiteBackground;
@@ -295,7 +297,7 @@ class Keyboard {
         var keys = "abcdefghijklmnopqrstuvwxyz"
             .chars
             .reduce([:], fun (acc, letter) {
-                acc[letter] = Letter(letter, notGuessed);
+                acc[letter] = Letter(letter, LetterStatus.notGuessed);
                 return acc;
             });
         this.keys = keys;
@@ -304,23 +306,23 @@ class Keyboard {
     reset() {
         var letters = "abcdefghijklmnopqrstuvwxyz".chars;
         for (var i = 0; i < letters.count; i += 1) {
-            this.keys[letters[i]].status = notGuessed;
+            this.keys[letters[i]].status = LetterStatus.notGuessed;
         }
     }
 
     update(guess) {
         for (var i = 0; i < 5; i += 1) {
             var letter = guess.letters[i];
-            if (letter.status == correctPosition) {
-                this.keys[letter.letter].status = correctPosition;
-            } else if (letter.status == wrongPosition) {
-                if (this.keys[letter.letter].status == noMatch or
-                    this.keys[letter.letter].status == notGuessed) {
-                    this.keys[letter.letter].status = wrongPosition;
+            if (letter.status == LetterStatus.correctPosition) {
+                this.keys[letter.letter].status = LetterStatus.correctPosition;
+            } else if (letter.status == LetterStatus.wrongPosition) {
+                if (this.keys[letter.letter].status == LetterStatus.noMatch or
+                    this.keys[letter.letter].status == LetterStatus.notGuessed) {
+                    this.keys[letter.letter].status = LetterStatus.wrongPosition;
                 }
-            } else if (letter.status == noMatch) {
-                if (this.keys[letter.letter].status == notGuessed) {
-                    this.keys[letter.letter].status = noMatch;
+            } else if (letter.status == LetterStatus.noMatch) {
+                if (this.keys[letter.letter].status == LetterStatus.notGuessed) {
+                    this.keys[letter.letter].status = LetterStatus.noMatch;
                 }
             }
         }
@@ -363,7 +365,7 @@ class Guess {
     reset() {
         for (var i = 0; i < 5; i += 1) {
             this.letters[i].letter = " ";
-            this.letters[i].status = notGuessed;
+            this.letters[i].status = LetterStatus.notGuessed;
         }
     }
 }
@@ -376,7 +378,7 @@ class Game {
         for (var i = 0; i < 6; i += 1) {
             var letters = [];
             for (var j = 0; j < 5; j += 1) {
-                letters.append(Letter(" ", notGuessed));
+                letters.append(Letter(" ", LetterStatus.notGuessed));
             }
             guesses.append(Guess(letters));
         }
@@ -392,13 +394,13 @@ class Game {
 
         this.keyboard.display();
 
-        if (this.status == invalidGuess) {
+        if (this.status == GameStatus.invalidGuess) {
             print "Your word must only be five letters long!";
-        } else if (this.status == wordNotInList) {
+        } else if (this.status == GameStatus.wordNotInList) {
             print "Word is not in this game's dictionary!";
-        } else if (this.status == loss) {
+        } else if (this.status == GameStatus.loss) {
             print "The word was: " + this.word;
-        } else if (this.status == win) {
+        } else if (this.status == GameStatus.win) {
             print "You won!";
         }
     }
@@ -410,16 +412,16 @@ class Game {
 
         this.keyboard.reset();
         this.guessCount = 0;
-        this.status = stillGoing;
+        this.status = GameStatus.stillGoing;
         this.word = this.wordList.choose();
     }
 
     submitGuess(guess) {
         if (guess.chars.count != 5) {
-            this.status = invalidGuess;
+            this.status = GameStatus.invalidGuess;
             return;
         } else if (!this.wordList.contains(guess)) {
-            this.status = wordNotInList;
+            this.status = GameStatus.wordNotInList;
             return;
         }
 
@@ -428,27 +430,27 @@ class Game {
 
         var letters = [];
         for (var i = 0; i < 5; i += 1) {
-            letters.append(Letter(guessChars[i], noMatch));
+            letters.append(Letter(guessChars[i], LetterStatus.noMatch));
         }
 
         var matchableLetters = [];
         for (i = 0; i < 5; i += 1) {
             var status = nil;
             if (guessChars[i] == wordChars[i]) {
-                letters[i].status = correctPosition;
+                letters[i].status = LetterStatus.correctPosition;
             } else {
                 matchableLetters.append(wordChars[i]);
             }
         }
 
         for (i = 0; i < 5; i += 1) {
-            if (letters[i].status == correctPosition) {
+            if (letters[i].status == LetterStatus.correctPosition) {
                 continue;
             }
 
             var matchIndex = matchableLetters.firstIndex(guessChars[i]);
             if (matchIndex != nil) {
-                letters[i].status = wrongPosition;
+                letters[i].status = LetterStatus.wrongPosition;
                 matchableLetters.deleteAt(matchIndex);
             }
         }
@@ -459,11 +461,11 @@ class Game {
         this.keyboard.update(newGuess);
 
         if (guess == this.word) {
-            this.status = win;
+            this.status = GameStatus.win;
         } else if (this.guessCount == 6) {
-            this.status = loss;
+            this.status = GameStatus.loss;
         } else {
-            this.status = stillGoing;
+            this.status = GameStatus.stillGoing;
         }
     }
 
@@ -471,7 +473,7 @@ class Game {
         while (true) {
             this.display();
 
-            if (this.status == win or this.status == loss) {
+            if (this.status == GameStatus.win or this.status == GameStatus.loss) {
                 var input = getInput("Would you like to play again? (y/n)");
                 if (input == "y") {
                     this.reset();

--- a/examples/wordle.lox
+++ b/examples/wordle.lox
@@ -1,28 +1,3 @@
-// ANSI escape codes
-var esc = "";
-var whiteBackground = esc + "[47m";
-var greenBackground = esc + "[42m";
-var yellowBackground = esc + "[43m";
-var greyBackground = esc + "[100m";
-var blackForeground = esc + "[30m";
-var reset = esc + "[0m";
-var clearScreen = esc + "[2J";
-
-enum LetterStatus {
-    notGuessed,
-    correctPosition,
-    wrongPosition,
-    noMatch
-}
-
-enum GameStatus {
-    win,
-    loss,
-    invalidGuess,
-    wordNotInList,
-    stillGoing
-}
-
 class WordList {
     init() {
         this.words = [
@@ -269,6 +244,68 @@ class WordList {
     }
 }
 
+enum Color {
+    case black, green, yellow, grey, white;
+
+    foregroundValue {
+        if (this == Color.black) {
+            return "30";
+        } else if (this == Color.green) {
+            return "32";
+        } else if (this == Color.yellow) {
+            return "33";
+        } else if (this == Color.white) {
+            return "37";
+        } else {
+            return "90";
+        }
+    }
+
+    backgroundValue {
+        if (this == Color.black) {
+            return "40";
+        } else if (this == Color.green) {
+            return "42";
+        } else if (this == Color.yellow) {
+            return "43";
+        } else if (this == Color.white) {
+            return "47";
+        } else {
+            return "100";
+        }
+    }
+}
+
+class Terminal {
+    class escape(sequence) {
+        return "[" + sequence;
+    }
+
+    class clearScreenStr() {
+        return Terminal.escape("2J");
+    }
+
+    class resetColorStr() {
+        return Terminal.escape("0m");
+    }
+
+    class foregroundStr(color) {
+        return Terminal.escape(color.foregroundValue + "m");
+    }
+
+    class backgroundStr(color) {
+        return Terminal.escape(color.backgroundValue + "m");
+    }
+}
+
+enum LetterStatus {
+    case notGuessed, correctPosition, wrongPosition, noMatch;
+}
+
+enum GameStatus {
+    case win, loss, invalidGuess, wordNotInList, stillGoing;
+}
+
 class Letter {
     init(letter, status) {
         this.letter = letter;
@@ -279,16 +316,19 @@ class Letter {
         var backgroundColor = nil;
 
         if (this.status == LetterStatus.correctPosition) {
-            backgroundColor = greenBackground;
+            backgroundColor = Color.green;
         } else if (this.status == LetterStatus.wrongPosition) {
-            backgroundColor = yellowBackground;
+            backgroundColor = Color.yellow;
         } else if (this.status == LetterStatus.noMatch) {
-            backgroundColor = greyBackground;
+            backgroundColor = Color.grey;
         } else {
-            backgroundColor = whiteBackground;
+            backgroundColor = Color.white;
         }
 
-        return backgroundColor + blackForeground + " " + this.letter + " " + reset;
+        return Terminal.backgroundStr(backgroundColor) +
+               Terminal.foregroundStr(Color.black) +
+               " " + this.letter + " " +
+               Terminal.resetColorStr();
     }
 }
 
@@ -387,7 +427,7 @@ class Game {
     }
 
     display() {
-        print clearScreen;
+        print Terminal.clearScreenStr();
         for (var i = 0; i < this.guesses.count; i += 1) {
             this.guesses[i].display();
         }

--- a/slox.xcodeproj/project.pbxproj
+++ b/slox.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		8702307E2B95AA2A0056FE57 /* ResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8702307D2B95AA2A0056FE57 /* ResolverTests.swift */; };
 		870230802B96E9580056FE57 /* LoxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8702307F2B96E9580056FE57 /* LoxClass.swift */; };
 		8730C77C2BD842A400EA8D30 /* LoxEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C77B2BD842A400EA8D30 /* LoxEnum.swift */; };
+		8730C77D2BD88F4200EA8D30 /* LoxEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C77B2BD842A400EA8D30 /* LoxEnum.swift */; };
 		8730DDE92BB250CE00372548 /* LoxDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730DDE82BB250CE00372548 /* LoxDictionary.swift */; };
 		8732838F2B93F89300E49035 /* NativeFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8732838E2B93F89300E49035 /* NativeFunction.swift */; };
 		873283902B93FC0900E49035 /* NativeFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8732838E2B93F89300E49035 /* NativeFunction.swift */; };
@@ -350,6 +351,7 @@
 				876A31572B8979BD0085A350 /* ScannerTests.swift in Sources */,
 				876A31602B89827B0085A350 /* LoxValue.swift in Sources */,
 				873CCB312B8EBB7800FC249A /* Statement.swift in Sources */,
+				8730C77D2BD88F4200EA8D30 /* LoxEnum.swift in Sources */,
 				8755B8B52B91984C00530DC4 /* LoxCallable.swift in Sources */,
 				87CB69762BB35EBA002A2E69 /* LoxDictionary.swift in Sources */,
 				87777E3D2BA1015F002E38F2 /* LoxList.swift in Sources */,

--- a/slox.xcodeproj/project.pbxproj
+++ b/slox.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		8702307C2B9575610056FE57 /* ResolvedStatement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873283932B95122800E49035 /* ResolvedStatement.swift */; };
 		8702307E2B95AA2A0056FE57 /* ResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8702307D2B95AA2A0056FE57 /* ResolverTests.swift */; };
 		870230802B96E9580056FE57 /* LoxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8702307F2B96E9580056FE57 /* LoxClass.swift */; };
+		8730C77C2BD842A400EA8D30 /* LoxEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C77B2BD842A400EA8D30 /* LoxEnum.swift */; };
 		8730DDE92BB250CE00372548 /* LoxDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730DDE82BB250CE00372548 /* LoxDictionary.swift */; };
 		8732838F2B93F89300E49035 /* NativeFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8732838E2B93F89300E49035 /* NativeFunction.swift */; };
 		873283902B93FC0900E49035 /* NativeFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8732838E2B93F89300E49035 /* NativeFunction.swift */; };
@@ -87,6 +88,7 @@
 		870230762B9574A90056FE57 /* TestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestPlan.xctestplan; sourceTree = "<group>"; };
 		8702307D2B95AA2A0056FE57 /* ResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverTests.swift; sourceTree = "<group>"; };
 		8702307F2B96E9580056FE57 /* LoxClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoxClass.swift; sourceTree = "<group>"; };
+		8730C77B2BD842A400EA8D30 /* LoxEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoxEnum.swift; sourceTree = "<group>"; };
 		8730DDE82BB250CE00372548 /* LoxDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoxDictionary.swift; sourceTree = "<group>"; };
 		8732838E2B93F89300E49035 /* NativeFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeFunction.swift; sourceTree = "<group>"; };
 		873283912B95118A00E49035 /* ResolvedExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolvedExpression.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				87BAFC482B9179CB0013E5FE /* LoxCallable.swift */,
 				8702307F2B96E9580056FE57 /* LoxClass.swift */,
 				8730DDE82BB250CE00372548 /* LoxDictionary.swift */,
+				8730C77B2BD842A400EA8D30 /* LoxEnum.swift */,
 				87EEDFBD2B96F52D00C7FE6D /* LoxInstance.swift */,
 				87777E3B2BA0FF70002E38F2 /* LoxList.swift */,
 				8741FB672BD0811300BBD8F1 /* LoxString.swift */,
@@ -296,6 +299,7 @@
 			files = (
 				876A31622B8986630085A350 /* ScanError.swift in Sources */,
 				87777E3C2BA0FF70002E38F2 /* LoxList.swift in Sources */,
+				8730C77C2BD842A400EA8D30 /* LoxEnum.swift in Sources */,
 				876560052B8825AC002BDE42 /* Token.swift in Sources */,
 				873283942B95122800E49035 /* ResolvedStatement.swift in Sources */,
 				876A315F2B897EEB0085A350 /* LoxValue.swift in Sources */,

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -198,7 +198,7 @@ class Interpreter {
 
         for caseToken in caseTokens {
             let caseInstance = LoxInstance(klass: enumClass)
-            caseInstance.properties["name"] = .string(caseToken.lexeme)
+            caseInstance.properties["name"] = try makeString(string: caseToken.lexeme)
             enumClass.properties[caseToken.lexeme] = .instance(caseInstance)
         }
 

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -82,6 +82,8 @@ class Interpreter {
                                        superclassExpr: superclassExpr,
                                        methods: methods,
                                        staticMethods: staticMethods)
+        case .enum(let nameToken, let caseTokens):
+            try handleEnumDeclaration(nameToken: nameToken, caseTokens: caseTokens)
         case .function(let name, let lambda):
             try handleFunctionDeclaration(name: name, lambda: lambda)
         case .return(let returnToken, let expr):
@@ -183,6 +185,20 @@ class Interpreter {
         }
 
         try environment.assignAtDepth(name: nameToken.lexeme, value: .instance(newClass), depth: 0)
+    }
+
+    private func handleEnumDeclaration(nameToken: Token, caseTokens: [Token]) throws {
+        let enumClass = LoxEnum(name: nameToken.lexeme,
+                                superclass: nil,
+                                methods: [:])
+
+        for caseToken in caseTokens {
+            let caseInstance = LoxInstance(klass: enumClass)
+            caseInstance.properties["name"] = .string(caseToken.lexeme)
+            enumClass.properties[caseToken.lexeme] = .instance(caseInstance)
+        }
+
+        environment.define(name: nameToken.lexeme, value: .instance(enumClass))
     }
 
     private func handleFunctionDeclaration(name: Token, lambda: ResolvedExpression) throws {

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -188,8 +188,12 @@ class Interpreter {
     }
 
     private func handleEnumDeclaration(nameToken: Token, caseTokens: [Token]) throws {
+        guard case .instance(let enumSuperclass as LoxClass) = try environment.getValue(name: "Enum") else {
+            fatalError()
+        }
+
         let enumClass = LoxEnum(name: nameToken.lexeme,
-                                superclass: nil,
+                                superclass: enumSuperclass,
                                 methods: [:])
 
         for caseToken in caseTokens {

--- a/slox/LoxEnum.swift
+++ b/slox/LoxEnum.swift
@@ -13,6 +13,10 @@ class LoxEnum: LoxClass {
         return ParameterList(normalParameters: parameters)
     }
 
+    override func set(propertyName: String, propertyValue: LoxValue) throws {
+        throw RuntimeError.onlyInstancesHaveProperties
+    }
+
     // NOTA BENE: This allows us to get back the case associated with its name
     override func call(interpreter: Interpreter, args: [LoxValue]) throws -> LoxValue {
         precondition(args.count == 1)

--- a/slox/LoxEnum.swift
+++ b/slox/LoxEnum.swift
@@ -1,0 +1,25 @@
+//
+//  LoxEnum.swift
+//  slox
+//
+//  Created by Danielle Kefford on 4/23/24.
+//
+
+class LoxEnum: LoxClass {
+    override var parameterList: ParameterList? {
+        let parameters = [
+            Token(type: .identifier, lexeme: "caseName", line: 0),
+        ]
+        return ParameterList(normalParameters: parameters)
+    }
+
+    // NOTA BENE: This allows us to get back the case associated with its name
+    override func call(interpreter: Interpreter, args: [LoxValue]) throws -> LoxValue {
+        precondition(args.count == 1)
+        guard case .string(let caseName)? = args.first else {
+            return .nil
+        }
+
+        return self.properties[caseName] ?? LoxValue.nil
+    }
+}

--- a/slox/LoxEnum.swift
+++ b/slox/LoxEnum.swift
@@ -16,10 +16,10 @@ class LoxEnum: LoxClass {
     // NOTA BENE: This allows us to get back the case associated with its name
     override func call(interpreter: Interpreter, args: [LoxValue]) throws -> LoxValue {
         precondition(args.count == 1)
-        guard case .string(let caseName)? = args.first else {
+        guard case .instance(let caseName as LoxString)? = args.first else {
             return .nil
         }
 
-        return self.properties[caseName] ?? LoxValue.nil
+        return self.properties[caseName.string] ?? LoxValue.nil
     }
 }

--- a/slox/LoxEnum.swift
+++ b/slox/LoxEnum.swift
@@ -16,14 +16,4 @@ class LoxEnum: LoxClass {
     override func set(propertyName: String, propertyValue: LoxValue) throws {
         throw RuntimeError.onlyInstancesHaveProperties
     }
-
-    // NOTA BENE: This allows us to get back the case associated with its name
-    override func call(interpreter: Interpreter, args: [LoxValue]) throws -> LoxValue {
-        precondition(args.count == 1)
-        guard case .instance(let caseName as LoxString)? = args.first else {
-            return .nil
-        }
-
-        return self.properties[caseName.string] ?? LoxValue.nil
-    }
 }

--- a/slox/LoxInstance.swift
+++ b/slox/LoxInstance.swift
@@ -19,7 +19,7 @@ class LoxInstance {
         if _klass == nil {
             // Only metaclasses should ever have a `nil` value for `_klass`
             let selfClass = self as! LoxClass
-            _klass = LoxClass(name: "\(selfClass.name) metaclass", superclass: nil, methods: [:])
+            _klass = LoxClass(name: "\(selfClass.name) metaclass", superclass: selfClass.superclass?.klass, methods: [:])
         }
         return _klass!
     }

--- a/slox/LoxValue.swift
+++ b/slox/LoxValue.swift
@@ -39,6 +39,8 @@ enum LoxValue: CustomStringConvertible, CustomDebugStringConvertible, Equatable,
             return "<function: \(function)>"
         case .instance(let loxString as LoxString):
             return "\"\(loxString.string)\""
+        case .instance(let enoom as LoxEnum):
+            return "<enum: \(enoom.name)>"
         case .instance(let klass as LoxClass):
             return "<class: \(klass.name)>"
         case .instance(let list as LoxList):
@@ -67,6 +69,10 @@ enum LoxValue: CustomStringConvertible, CustomDebugStringConvertible, Equatable,
             string.append("]")
             return string
         case .instance(let instance):
+            if instance.klass is LoxEnum {
+                let caseName = instance.properties["name"]!
+                return "<enum case: \(instance.klass.name).\(caseName)>"
+            }
             return "<instance: \(instance.klass.name)>"
         }
     }
@@ -90,6 +96,8 @@ enum LoxValue: CustomStringConvertible, CustomDebugStringConvertible, Equatable,
             return leftString.string == rightString.string
         case (.instance(let leftList as LoxList), .instance(let rightList as LoxList)):
             return leftList.elements == rightList.elements
+        case (.instance(let leftInstance), .instance(let rightInstance)):
+            return leftInstance === rightInstance
         default:
             return false
         }

--- a/slox/NativeFunction.swift
+++ b/slox/NativeFunction.swift
@@ -22,6 +22,7 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
     case randDouble
     case charsNative
     case firstIndexNative
+    case allCasesNative
 
     var parameterList: ParameterList? {
         let normalParameters: [String] = switch self {
@@ -53,6 +54,8 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             ["this"]
         case .firstIndexNative:
             ["this", "element"]
+        case .allCasesNative:
+            ["this"]
         }
 
         return ParameterList(
@@ -187,6 +190,17 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             }
 
             return .nil
+        case .allCasesNative:
+            guard case .instance(let loxEnum as LoxEnum) = args[0] else {
+                fatalError()
+            }
+
+            var allCases: [LoxValue] = []
+            for (_, enumCase) in loxEnum.properties {
+                allCases.append(enumCase)
+            }
+
+            return try interpreter.makeList(elements: allCases)
         }
     }
 }

--- a/slox/ParseError.swift
+++ b/slox/ParseError.swift
@@ -23,7 +23,10 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
     case missingCloseParenForForStatement(Token)
     case missingSemicolonAfterForLoopCondition(Token)
     case missingClassName(Token)
+    case missingEnumName(Token)
     case missingOpenBraceBeforeClassBody(Token)
+    case missingOpenBraceBeforeEnumBody(Token)
+    case missingCloseBraceAfterEnumBody(Token)
     case missingFunctionName(Token)
     case missingOpenParenForFunctionDeclaration(Token)
     case missingParameterName(Token)
@@ -68,8 +71,14 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(token.line)] Error: expected semicolon after `for` loop condition"
         case .missingClassName(let token):
             return "[Line \(token.line)] Error: expected class name"
+        case .missingEnumName(let token):
+            return "[Line \(token.line)] Error: expected enum name"
         case .missingOpenBraceBeforeClassBody(let token):
             return "[Line \(token.line)] Error: expected open brace before class body"
+        case .missingOpenBraceBeforeEnumBody(let token):
+            return "[Line \(token.line)] Error: expected open brace before enum body"
+        case .missingCloseBraceAfterEnumBody(let token):
+            return "[Line \(token.line)] Error: expected close brace after enum body"
         case .missingFunctionName(let token):
             return "[Line \(token.line)] Error: expected function name"
         case .missingOpenParenForFunctionDeclaration(let token):

--- a/slox/ParseError.swift
+++ b/slox/ParseError.swift
@@ -24,6 +24,8 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
     case missingSemicolonAfterForLoopCondition(Token)
     case missingClassName(Token)
     case missingEnumName(Token)
+    case missingCaseKeyword(Token)
+    case missingSemicolonAfterCaseClause(Token)
     case missingOpenBraceBeforeClassBody(Token)
     case missingOpenBraceBeforeEnumBody(Token)
     case missingCloseBraceAfterEnumBody(Token)
@@ -73,6 +75,10 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(token.line)] Error: expected class name"
         case .missingEnumName(let token):
             return "[Line \(token.line)] Error: expected enum name"
+        case .missingCaseKeyword(let token):
+            return "[Line \(token.line)] Error: expected `case` keyword before list of names"
+        case .missingSemicolonAfterCaseClause(let token):
+            return "[Line \(token.line)] Error: expected semicolon after `case` clause"
         case .missingOpenBraceBeforeClassBody(let token):
             return "[Line \(token.line)] Error: expected open brace before class body"
         case .missingOpenBraceBeforeEnumBody(let token):

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -144,11 +144,18 @@ struct Parser {
 
         var enumCases: [Token] = []
         var methods: [Statement] = []
+        var staticMethods: [Statement] = []
 
         while currentToken.type != .rightBrace && currentToken.type != .eof {
             if currentTokenMatchesAny(types: [.case]) {
                 let newEnumCases = try parseCaseElementList()
                 enumCases.append(contentsOf: newEnumCases)
+            } else if currentTokenMatchesAny(types: [.class]) {
+                // It's a little weird to look for the "class" keyword here,
+                // for an enum, but we want to be consistent with the Lox specification,
+                // and enums are _somewhat_ like classes anyway
+                let staticMethod = try parseFunction()
+                staticMethods.append(staticMethod)
             } else {
                 let method = try parseFunction()
                 methods.append(method)
@@ -159,7 +166,7 @@ struct Parser {
             throw ParseError.missingCloseParenAfterArguments(currentToken)
         }
 
-        return .enum(enumName, enumCases, methods)
+        return .enum(enumName, enumCases, methods, staticMethods)
     }
 
     mutating private func parseFunctionDeclaration() throws -> Statement? {

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -151,7 +151,7 @@ struct Parser {
                 let newEnumCases = try parseCaseElementList()
                 enumCases.append(contentsOf: newEnumCases)
             } else if currentTokenMatchesAny(types: [.class]) {
-                // It's a little weird to look for the "class" keyword here,
+                // It's a little weird to look for the "class" keyword here
                 // for an enum, but we want to be consistent with the Lox specification,
                 // and enums are _somewhat_ like classes anyway
                 let staticMethod = try parseFunction()

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -39,7 +39,8 @@ struct Parser {
     //                   | statement ;
     //    classDecl      → "class" IDENTIFIER ( "<" IDENTIFIER )?
     //                     "{" function* "}" ;
-    //    enumDecl       → "enum" IDENTIFIER "{" (IDENTIFIER ( "," IDENTIFIER )*)?
+    //    enumDecl       → "enum" IDENTIFIER "{"
+    //                     "case" (IDENTIFIER ( "," IDENTIFIER )*)? ";"
     //                     function* "}" ;
     //    funDecl        → "fun" function ;
     //    function       → IDENTIFIER "(" parameters? ")" block ;
@@ -140,6 +141,10 @@ struct Parser {
             throw ParseError.missingOpenBraceBeforeEnumBody(currentToken)
         }
 
+        guard currentTokenMatchesAny(types: [.case]) else {
+            throw ParseError.missingCaseKeyword(currentToken)
+        }
+
         var enumCases: [Token] = []
         if currentToken.type != .rightBrace {
             repeat {
@@ -149,6 +154,10 @@ struct Parser {
 
                 enumCases.append(enumCase)
             } while currentTokenMatchesAny(types: [.comma])
+        }
+
+        guard currentTokenMatchesAny(types: [.semicolon]) else {
+            throw ParseError.missingSemicolonAfterCaseClause(currentToken)
         }
 
         var methods: [Statement] = []

--- a/slox/ResolvedStatement.swift
+++ b/slox/ResolvedStatement.swift
@@ -16,7 +16,7 @@ indirect enum ResolvedStatement: Equatable {
     case function(Token, ResolvedExpression)
     case `return`(Token, ResolvedExpression?)
     case `class`(Token, ResolvedExpression?, [ResolvedStatement], [ResolvedStatement])
-    case `enum`(Token, [Token], [ResolvedStatement])
+    case `enum`(Token, [Token], [ResolvedStatement], [ResolvedStatement])
     case `break`(Token)
     case `continue`(Token)
 }

--- a/slox/ResolvedStatement.swift
+++ b/slox/ResolvedStatement.swift
@@ -16,6 +16,7 @@ indirect enum ResolvedStatement: Equatable {
     case function(Token, ResolvedExpression)
     case `return`(Token, ResolvedExpression?)
     case `class`(Token, ResolvedExpression?, [ResolvedStatement], [ResolvedStatement])
+    case `enum`(Token, [Token])
     case `break`(Token)
     case `continue`(Token)
 }

--- a/slox/ResolvedStatement.swift
+++ b/slox/ResolvedStatement.swift
@@ -16,7 +16,7 @@ indirect enum ResolvedStatement: Equatable {
     case function(Token, ResolvedExpression)
     case `return`(Token, ResolvedExpression?)
     case `class`(Token, ResolvedExpression?, [ResolvedStatement], [ResolvedStatement])
-    case `enum`(Token, [Token])
+    case `enum`(Token, [Token], [ResolvedStatement])
     case `break`(Token)
     case `continue`(Token)
 }

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -212,6 +212,14 @@ struct Resolver {
         }
         scopeStack.lastMutable["this"] = true
 
+        var caseNameSet: Set<String> = Set()
+        for caseToken in caseTokens {
+            let (inserted, _) = caseNameSet.insert(caseToken.lexeme)
+            if !inserted {
+                throw ResolverError.duplicateCaseNamesNotAllowed(caseToken)
+            }
+        }
+
         let resolvedMethods = try methods.map { method in
             guard case .function(let nameToken, let lambdaExpr) = method else {
                 throw ResolverError.notAFunction
@@ -225,6 +233,10 @@ struct Resolver {
         let resolvedStaticMethods = try staticMethods.map { method in
             guard case .function(let nameToken, let lambdaExpr) = method else {
                 throw ResolverError.notAFunction
+            }
+
+            if nameToken.lexeme == "init" {
+                throw ResolverError.staticInitsNotAllowed
             }
 
             return try handleFunctionDeclaration(nameToken: nameToken,

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -57,6 +57,8 @@ struct Resolver {
                                               superclassExpr: superclassExpr,
                                               methods: methods,
                                               staticMethods: staticMethods)
+        case .enum(let nameToken, let caseTokens):
+            return try handleEnumDeclaration(nameToken: nameToken, caseTokens: caseTokens)
         case .function(let nameToken, let lambdaExpr):
             return try handleFunctionDeclaration(nameToken: nameToken,
                                                  lambdaExpr: lambdaExpr,
@@ -183,6 +185,15 @@ struct Resolver {
 
         return .class(nameToken, resolvedSuperclassExpr, resolvedMethods, resolvedStaticMethods)
     }
+
+    mutating private func handleEnumDeclaration(nameToken: Token,
+                                                caseTokens: [Token]) throws -> ResolvedStatement {
+        try declareVariable(name: nameToken.lexeme)
+        defineVariable(name: nameToken.lexeme)
+
+        return .enum(nameToken, caseTokens)
+    }
+
 
     mutating private func handleFunctionDeclaration(nameToken: Token,
                                                     lambdaExpr: Expression,

--- a/slox/ResolverError.swift
+++ b/slox/ResolverError.swift
@@ -22,6 +22,7 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
     case cannotContinueOutsideLoop
     case functionsMustHaveAParameterList
     case cannotUseSplatOperatorOutOfContext
+    case duplicateCaseNamesNotAllowed(Token)
 
     var description: String {
         switch self {
@@ -53,6 +54,8 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
             return "Functions must have a parameter list"
         case .cannotUseSplatOperatorOutOfContext:
             return "Cannot use splat operator in this context"
+        case .duplicateCaseNamesNotAllowed(let token):
+            return "Cannot use duplicate case names in enum: \(token.lexeme)"
         }
     }
 }

--- a/slox/Scanner.swift
+++ b/slox/Scanner.swift
@@ -32,6 +32,7 @@ struct Scanner {
         "while": .while,
         "break": .break,
         "continue": .continue,
+        "enum": .enum,
     ]
 
     init(source: String) {

--- a/slox/Scanner.swift
+++ b/slox/Scanner.swift
@@ -33,6 +33,7 @@ struct Scanner {
         "break": .break,
         "continue": .continue,
         "enum": .enum,
+        "case": .case
     ]
 
     init(source: String) {

--- a/slox/StandardLibrary.swift
+++ b/slox/StandardLibrary.swift
@@ -12,6 +12,12 @@ class String {
     }
 }
 
+class Enum {
+    class allCases {
+        return allCasesNative(this);
+    }
+}
+
 class List {
     clone() {
         return this + [];

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -16,7 +16,7 @@ indirect enum Statement: Equatable {
     case function(Token, Expression)
     case `return`(Token, Expression?)
     case `class`(Token, Expression?, [Statement], [Statement])
-    case `enum`(Token, [Token], [Statement])
+    case `enum`(Token, [Token], [Statement], [Statement])
     case `break`(Token)
     case `continue`(Token)
 }

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -16,7 +16,7 @@ indirect enum Statement: Equatable {
     case function(Token, Expression)
     case `return`(Token, Expression?)
     case `class`(Token, Expression?, [Statement], [Statement])
-    case `enum`(Token, [Token])
+    case `enum`(Token, [Token], [Statement])
     case `break`(Token)
     case `continue`(Token)
 }

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -16,6 +16,7 @@ indirect enum Statement: Equatable {
     case function(Token, Expression)
     case `return`(Token, Expression?)
     case `class`(Token, Expression?, [Statement], [Statement])
+    case `enum`(Token, [Token])
     case `break`(Token)
     case `continue`(Token)
 }

--- a/slox/TokenType.swift
+++ b/slox/TokenType.swift
@@ -63,6 +63,7 @@ enum TokenType: Equatable {
     case `break`
     case `continue`
     case `enum`
+    case `case`
 
     case eof
 }

--- a/slox/TokenType.swift
+++ b/slox/TokenType.swift
@@ -62,6 +62,7 @@ enum TokenType: Equatable {
     case `while`
     case `break`
     case `continue`
+    case `enum`
 
     case eof
 }

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -1015,4 +1015,57 @@ bar
         ])
         XCTAssertEqual(actual, expected)
     }
+
+    func testInterpretEnumWithMethod() throws {
+        let input = """
+enum Color {
+    case red, green, blue;
+
+    isRed() {
+        if (this == Color.red) {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+Color.blue.isRed()
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .boolean(false)
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretEnumWithClassLevelMethod() throws {
+        let input = """
+enum Color {
+    case red, green, blue;
+
+    class lookup(name) {
+        if (name == "red") {
+            return Color.red;
+        } else if (name == "green") {
+            return Color.green;
+        } else if (name == "blue") {
+            return Color.blue;
+        }
+
+        return nil;
+    }
+}
+
+Color.lookup("green").name
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        // NOTA BENE: We need to compare names here because we do not
+        // currently have a means of getting a handle to a specific
+        // Lox enum case from within Swift.
+        let expected: LoxValue = try interpreter.makeString(string: "green")
+        XCTAssertEqual(actual, expected)
+    }
 }

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -1068,4 +1068,38 @@ Color.lookup("green").name
         let expected: LoxValue = try interpreter.makeString(string: "green")
         XCTAssertEqual(actual, expected)
     }
+
+    func testInterpretEnumWithNoCases() throws {
+        let input = """
+enum Life {
+    class theAnswer() {
+        return 42;
+    }
+}
+
+Life.theAnswer();
+"""
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .int(42)
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretComparingCasesOfDifferentEnumsButSameNames() throws {
+        let input = """
+enum PizzaSize {
+    case small, medium, large;
+}
+
+enum ClothingSize {
+  case small, medium, large;
+}
+
+PizzaSize.medium == ClothingSize.medium;
+"""
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = .boolean(false)
+        XCTAssertEqual(actual, expected)
+    }
 }

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -1561,4 +1561,99 @@ final class ParserTests: XCTestCase {
         ]
         XCTAssertEqual(actual, expected)
     }
+
+    func testParseEnumDeclarationWithMethods() throws {
+        // enum Foo {
+        //     case foo, bar, baz;
+        //     isBar() {
+        //         if (this == Foo.bar) {
+        //             return true;
+        //         }
+        //         return false;
+        //     }
+        // }
+        let tokens: [Token] = [
+            Token(type: .enum, lexeme: "enum", line: 1),
+            Token(type: .identifier, lexeme: "Foo", line: 1),
+            Token(type: .leftBrace, lexeme: "{", line: 1),
+
+            Token(type: .case, lexeme: "case", line: 2),
+            Token(type: .identifier, lexeme: "foo", line: 2),
+            Token(type: .comma, lexeme: ",", line: 2),
+            Token(type: .identifier, lexeme: "bar", line: 2),
+            Token(type: .comma, lexeme: ",", line: 2),
+            Token(type: .identifier, lexeme: "baz", line: 2),
+            Token(type: .semicolon, lexeme: ";", line: 2),
+
+            Token(type: .identifier, lexeme: "isBar", line: 3),
+            Token(type: .leftParen, lexeme: "(", line: 3),
+            Token(type: .rightParen, lexeme: ")", line: 3),
+            Token(type: .leftBrace, lexeme: "{", line: 3),
+
+            Token(type: .if, lexeme: "if", line: 4),
+            Token(type: .leftParen, lexeme: "(", line: 4),
+            Token(type: .this, lexeme: "this", line: 4),
+            Token(type: .equalEqual, lexeme: "==", line: 4),
+            Token(type: .identifier, lexeme: "Foo", line: 4),
+            Token(type: .dot, lexeme: ".", line: 4),
+            Token(type: .identifier, lexeme: "bar", line: 4),
+            Token(type: .rightParen, lexeme: ")", line: 4),
+            Token(type: .leftBrace, lexeme: "{", line: 4),
+
+            Token(type: .return, lexeme: "return", line: 5),
+            Token(type: .true, lexeme: "true", line: 5),
+            Token(type: .semicolon, lexeme: ";", line: 5),
+
+            Token(type: .rightBrace, lexeme: "}", line: 6),
+
+            Token(type: .return, lexeme: "return", line: 7),
+            Token(type: .false, lexeme: "false", line: 7),
+            Token(type: .semicolon, lexeme: ";", line: 7),
+
+            Token(type: .rightBrace, lexeme: "}", line: 8),
+
+            Token(type: .rightBrace, lexeme: "}", line: 9),
+            Token(type: .eof, lexeme: "", line: 9)
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let actual = try parser.parse()
+        let expected: [Statement] = [
+            .enum(
+                Token(type: .identifier, lexeme: "Foo", line: 1),
+                [
+                    Token(type: .identifier, lexeme: "foo", line: 2),
+                    Token(type: .identifier, lexeme: "bar", line: 2),
+                    Token(type: .identifier, lexeme: "baz", line: 2),
+                ],
+                [
+                    .function(
+                        Token(type: .identifier, lexeme: "isBar", line: 3),
+                        .lambda(
+                            ParameterList(
+                                normalParameters: [],
+                                variadicParameter: nil),
+                            [
+                                .if(
+                                    .binary(
+                                        .this(Token(type: .this, lexeme: "this", line: 4)),
+                                        Token(type: .equalEqual, lexeme: "==", line: 4),
+                                        .get(
+                                            .variable(Token(type: .identifier, lexeme: "Foo", line: 4)),
+                                            Token(type: .identifier, lexeme: "bar", line: 4))),
+                                    .block([
+                                        .return(
+                                            Token(type: .return, lexeme: "return", line: 5),
+                                            .literal(.boolean(true))),
+                                    ]),
+                                    nil),
+                                .return(
+                                    Token(type: .return, lexeme: "return", line: 7),
+                                    .literal(.boolean(false)))
+                            ]))
+                ],
+                []),
+        ]
+        XCTAssertEqual(actual, expected)
+    }
 }

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -540,4 +540,35 @@ final class ResolverTests: XCTestCase {
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
     }
+
+    func testResolveEnumWithDuplicateCaseNames() throws {
+        // enum Color {
+        //     case red, green, blue, violet;
+        //     case orange, yellow, green, indigo;
+        // }
+        let statements: [Statement] = [
+            .enum(
+                Token(type: .identifier, lexeme: "color", line: 1),
+                [
+                    Token(type: .identifier, lexeme: "red", line: 2),
+                    Token(type: .identifier, lexeme: "green", line: 2),
+                    Token(type: .identifier, lexeme: "blue", line: 2),
+                    Token(type: .identifier, lexeme: "violet", line: 2),
+                    Token(type: .identifier, lexeme: "orange", line: 3),
+                    Token(type: .identifier, lexeme: "yellow", line: 3),
+                    Token(type: .identifier, lexeme: "green", line: 3),
+                    Token(type: .identifier, lexeme: "indigo", line: 3),
+                ],
+                [],
+                [])
+        ]
+
+        var resolver = Resolver()
+        let expectedError = ResolverError.duplicateCaseNamesNotAllowed(
+            Token(type: .identifier, lexeme: "green", line: 3)
+        )
+        XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
+            XCTAssertEqual(actualError as! ResolverError, expectedError)
+        }
+    }
 }

--- a/sloxTests/ScannerTests.swift
+++ b/sloxTests/ScannerTests.swift
@@ -112,7 +112,7 @@ final class ScannerTests: XCTestCase {
     }
 
     func testScanningOfKeywords() throws {
-        let source = "and class else false for fun if nil or print return super this true var while break continue"
+        let source = "and class else false for fun if nil or print return super this true var while break continue enum case"
         var scanner = Scanner(source: source)
         let actual = try! scanner.scanTokens()
         let expected: [Token] = [
@@ -134,6 +134,8 @@ final class ScannerTests: XCTestCase {
             Token(type: .while, lexeme: "while", line: 1),
             Token(type: .break, lexeme: "break", line: 1),
             Token(type: .continue, lexeme: "continue", line: 1),
+            Token(type: .enum, lexeme: "enum", line: 1),
+            Token(type: .case, lexeme: "case", line: 1),
             Token(type: .eof, lexeme: "", line: 1),
         ]
 


### PR DESCRIPTION
This PR introduces support for enums in this implementation of Lox; the following changes were made:

* There are new `emum` and `case` keywords in `TokenType`, and the scanner was updated accordingly to account for them.
* A new function was added to the parser, namely `parseEnumDeclaration()` to produce new `Statement.enum` nodes in the AST. There is also a new helper method, `parseCaseElementList()`, which is called by `parseEnumDeclaration()` and improves clarity of the code (hopefully).
* The parser allows for multiple case list declarations, even after method declarations, as well as allowing for _no_ cases defined, in which case the enum acts as a namespace for any methods declared inside. There are also a few new cases in `ParserError`s relevant to any errors encountered when processing enum declarations.
* The resolver essentially does the same thing for enums as it does for classes, and emits new `ResolvedStatement.enum` nodes. Although no logic specifically uses it, there is also a new `ClassType.enum` case in case there needs to be any sort of special scoping logic in the future. It also ensures that `this` for enums resolves the same way as for class instances, namely that it computes the depth in the environment stack and puts it in the resultant AST, which the interpreter can then find and get a reference to the relevant enum case instance.
* A new class `LoxEnum` which is associated by the interpreter with the new `Enum` class defined in the standard library. Having the same motivation as I had previously with `LoxString`, this allows us to define an `allCases` computed property for all enums. This new property in turn calls a new method in `NativeFunction`, namely `allCasesNative`, and works exactly like the one exposed in Swift.
* The interpreter now processes enum declarations in the new function, `handleEnumDeclaration()`, which does a few things:
  * It instantiates a new instance `LoxEnum` and associates its superclass with the one found by looking up the class for the Lox `Enum` class.
  * For each enum case, an instance of `LoxInstance` is created, with its class as `LoxEnum`, and its `name` property associated with the case name. This means that the enum case's name can be accessed within slox.
  * Instance-level and static method declarations for enums are handled identically as for classes, and since that was the case, I introduced a new helper method, `makeMethodLookup()` which is used for both class and enum declarations. This reduced a _lot_ of boilerplate code.
* It should be noted that in the midst of adding support for static methods, I found a bug in `LoxInstance` which caused their lookups to fail. This too has been addressed in this PR.
* `LoxValue` needed to be updated for both the of printing of raw enum and enum case values, as well as for the equality testing of enum case values.
* The example Wordle script was updated to take advantage of enums