### PR TITLE
Implement `switch` statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ x *= 2;
 
 ### Flow control
 
-There are three types of flow control statements in slox: `if` blocks:
+There are four types of flow control statements in slox, two of which are non-looping constructs: `if` blocks:
 
 ```
 if (x == 42) {
@@ -104,7 +104,49 @@ if (x == 42) {
 }
 ```
 
-... `while` loops:
+... and `switch` statements
+
+```
+var foo = 42;
+switch (foo) {
+case 42
+    print "The answer!";
+default:
+    print "nope";
+}
+```
+
+`switch` statements also support having multiple values associated with one `case`:
+
+```
+var foo = 3;
+switch (foo) {
+case 1:
+    print "one";
+case 2, 3, 4:
+    print "two, three, or four";
+default:
+    print "something else";
+}
+```
+
+... or multiple inner statements associated with a `case`:
+
+```
+var foo = 3;
+switch (foo) {
+case 1:
+    print "one";
+case 2, 3, 4:
+    print "two";
+    print "three";
+    print "or four";
+default:
+    print "something else";
+}
+```
+
+There are also two looping statements, one of them the `while` statement:
 
 ```
 var i = 0;
@@ -114,7 +156,7 @@ while (i < 3) {
 }
 ```
 
-... and `for` loops
+... and the other a `for` statement:
 
 ```
 for (var i = 0; i < 3; i = i + 1) {
@@ -132,6 +174,23 @@ while (true) {
         break;
     }
     i = i + 1;
+}
+```
+
+... or a `switch` statement:
+
+```
+var foo = 3;
+switch (foo) {
+case 1:
+    print "one";
+default:
+    if (foo < 5) {
+        print "less than five";
+        break;
+    }
+
+    print "greater than four";      // This is never called
 }
 ```
 
@@ -327,6 +386,17 @@ var randomColor = Color.choose();
 randomColor.name         // Prints one of "red", "green", or "blue"
 ```
 
+Enums can also be used for namespacing by only exposing class-level methods and no cases, and without having to instantiate a class:
+
+```
+enum Math {
+    class add(a, b) {
+        return a + b;
+    }
+}
+
+Math.add(2, 3);          // Prints "5"
+```
 
 ### Collections
 

--- a/examples/wordle.lox
+++ b/examples/wordle.lox
@@ -248,30 +248,36 @@ enum Color {
     case black, green, yellow, grey, white;
 
     foregroundValue {
-        if (this == Color.black) {
+        switch (this) {
+        case Color.black:
             return "30";
-        } else if (this == Color.green) {
+        case Color.green:
             return "32";
-        } else if (this == Color.yellow) {
+        case Color.yellow:
             return "33";
-        } else if (this == Color.white) {
+        case Color.white:
             return "37";
-        } else {
+        case Color.grey:
             return "90";
+        default:
+            return nil;
         }
     }
 
     backgroundValue {
-        if (this == Color.black) {
+        switch (this) {
+        case Color.black:
             return "40";
-        } else if (this == Color.green) {
+        case Color.green:
             return "42";
-        } else if (this == Color.yellow) {
+        case Color.yellow:
             return "43";
-        } else if (this == Color.white) {
+        case Color.white:
             return "47";
-        } else {
+        case Color.grey:
             return "100";
+        default:
+            return nil;
         }
     }
 }

--- a/slox.xcodeproj/project.pbxproj
+++ b/slox.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		8730C77D2BD88F4200EA8D30 /* LoxEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C77B2BD842A400EA8D30 /* LoxEnum.swift */; };
 		8730C7832BDC4A9D00EA8D30 /* SwitchCaseDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C7822BDC4A9D00EA8D30 /* SwitchCaseDeclaration.swift */; };
 		8730C7852BDC4B4300EA8D30 /* ResolvedSwitchCaseDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C7842BDC4B4300EA8D30 /* ResolvedSwitchCaseDeclaration.swift */; };
+		8730C7862BDC6DFB00EA8D30 /* SwitchCaseDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C7822BDC4A9D00EA8D30 /* SwitchCaseDeclaration.swift */; };
+		8730C7872BDC6DFF00EA8D30 /* ResolvedSwitchCaseDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C7842BDC4B4300EA8D30 /* ResolvedSwitchCaseDeclaration.swift */; };
 		8730DDE92BB250CE00372548 /* LoxDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730DDE82BB250CE00372548 /* LoxDictionary.swift */; };
 		8732838F2B93F89300E49035 /* NativeFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8732838E2B93F89300E49035 /* NativeFunction.swift */; };
 		873283902B93FC0900E49035 /* NativeFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8732838E2B93F89300E49035 /* NativeFunction.swift */; };
@@ -358,6 +360,7 @@
 				876A315C2B897C000085A350 /* Token.swift in Sources */,
 				876A31572B8979BD0085A350 /* ScannerTests.swift in Sources */,
 				876A31602B89827B0085A350 /* LoxValue.swift in Sources */,
+				8730C7862BDC6DFB00EA8D30 /* SwitchCaseDeclaration.swift in Sources */,
 				873CCB312B8EBB7800FC249A /* Statement.swift in Sources */,
 				8730C77D2BD88F4200EA8D30 /* LoxEnum.swift in Sources */,
 				8755B8B52B91984C00530DC4 /* LoxCallable.swift in Sources */,
@@ -371,6 +374,7 @@
 				873CCB272B8E7AD100FC249A /* ParserTests.swift in Sources */,
 				876A315D2B897C020085A350 /* Scanner.swift in Sources */,
 				87EEDFBF2B9920F900C7FE6D /* LoxClass.swift in Sources */,
+				8730C7872BDC6DFF00EA8D30 /* ResolvedSwitchCaseDeclaration.swift in Sources */,
 				876A315B2B897BFD0085A350 /* TokenType.swift in Sources */,
 				87EEDFC02B9920FD00C7FE6D /* LoxInstance.swift in Sources */,
 				873CCB292B8E7B6900FC249A /* ParseError.swift in Sources */,

--- a/slox.xcodeproj/project.pbxproj
+++ b/slox.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		870230802B96E9580056FE57 /* LoxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8702307F2B96E9580056FE57 /* LoxClass.swift */; };
 		8730C77C2BD842A400EA8D30 /* LoxEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C77B2BD842A400EA8D30 /* LoxEnum.swift */; };
 		8730C77D2BD88F4200EA8D30 /* LoxEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C77B2BD842A400EA8D30 /* LoxEnum.swift */; };
+		8730C7832BDC4A9D00EA8D30 /* SwitchCaseDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C7822BDC4A9D00EA8D30 /* SwitchCaseDeclaration.swift */; };
+		8730C7852BDC4B4300EA8D30 /* ResolvedSwitchCaseDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730C7842BDC4B4300EA8D30 /* ResolvedSwitchCaseDeclaration.swift */; };
 		8730DDE92BB250CE00372548 /* LoxDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8730DDE82BB250CE00372548 /* LoxDictionary.swift */; };
 		8732838F2B93F89300E49035 /* NativeFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8732838E2B93F89300E49035 /* NativeFunction.swift */; };
 		873283902B93FC0900E49035 /* NativeFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8732838E2B93F89300E49035 /* NativeFunction.swift */; };
@@ -90,6 +92,8 @@
 		8702307D2B95AA2A0056FE57 /* ResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverTests.swift; sourceTree = "<group>"; };
 		8702307F2B96E9580056FE57 /* LoxClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoxClass.swift; sourceTree = "<group>"; };
 		8730C77B2BD842A400EA8D30 /* LoxEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoxEnum.swift; sourceTree = "<group>"; };
+		8730C7822BDC4A9D00EA8D30 /* SwitchCaseDeclaration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCaseDeclaration.swift; sourceTree = "<group>"; };
+		8730C7842BDC4B4300EA8D30 /* ResolvedSwitchCaseDeclaration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolvedSwitchCaseDeclaration.swift; sourceTree = "<group>"; };
 		8730DDE82BB250CE00372548 /* LoxDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoxDictionary.swift; sourceTree = "<group>"; };
 		8732838E2B93F89300E49035 /* NativeFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeFunction.swift; sourceTree = "<group>"; };
 		873283912B95118A00E49035 /* ResolvedExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolvedExpression.swift; sourceTree = "<group>"; };
@@ -184,6 +188,7 @@
 				876A31662B8C11810085A350 /* Parser.swift */,
 				873283912B95118A00E49035 /* ResolvedExpression.swift */,
 				873283932B95122800E49035 /* ResolvedStatement.swift */,
+				8730C7842BDC4B4300EA8D30 /* ResolvedSwitchCaseDeclaration.swift */,
 				873283952B95127100E49035 /* Resolver.swift */,
 				873283972B9523AD00E49035 /* ResolverError.swift */,
 				873CCB222B8D617C00FC249A /* RuntimeError.swift */,
@@ -191,6 +196,7 @@
 				876560062B8827F9002BDE42 /* Scanner.swift */,
 				8792A9982BB36C66009842D8 /* StandardLibrary.swift */,
 				873CCB2F2B8EAEC100FC249A /* Statement.swift */,
+				8730C7822BDC4A9D00EA8D30 /* SwitchCaseDeclaration.swift */,
 				876560042B8825AC002BDE42 /* Token.swift */,
 				876560022B882259002BDE42 /* TokenType.swift */,
 				87BAFC4A2B918C520013E5FE /* UserDefinedFunction.swift */,
@@ -301,6 +307,7 @@
 				876A31622B8986630085A350 /* ScanError.swift in Sources */,
 				87777E3C2BA0FF70002E38F2 /* LoxList.swift in Sources */,
 				8730C77C2BD842A400EA8D30 /* LoxEnum.swift in Sources */,
+				8730C7852BDC4B4300EA8D30 /* ResolvedSwitchCaseDeclaration.swift in Sources */,
 				876560052B8825AC002BDE42 /* Token.swift in Sources */,
 				873283942B95122800E49035 /* ResolvedStatement.swift in Sources */,
 				876A315F2B897EEB0085A350 /* LoxValue.swift in Sources */,
@@ -317,6 +324,7 @@
 				87BAFC4B2B918C520013E5FE /* UserDefinedFunction.swift in Sources */,
 				8792A9992BB36C66009842D8 /* StandardLibrary.swift in Sources */,
 				873CCB332B8ED8B900FC249A /* Environment.swift in Sources */,
+				8730C7832BDC4A9D00EA8D30 /* SwitchCaseDeclaration.swift in Sources */,
 				876A31652B8C04990085A350 /* Expression.swift in Sources */,
 				876560032B882259002BDE42 /* TokenType.swift in Sources */,
 				87EEDFBE2B96F52D00C7FE6D /* LoxInstance.swift in Sources */,

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -114,9 +114,6 @@ class Interpreter {
         }
     }
 
-//    var foo = 42;
-//    var bar = 21;
-//    switch (bar) { case 21: if (foo > bar) { break; } foo = 0; }
     private func handleSwitchStatement(testExpr: ResolvedExpression,
                                        switchCaseDecls: [ResolvedSwitchCaseDeclaration],
                                        switchDefaultStmts: [ResolvedStatement]?) throws {

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -122,7 +122,7 @@ class Interpreter {
                 try evaluate(expr: valueExpr)
             }
 
-            if caseValues == nil || caseValues!.contains(testValue) {
+            if caseValues?.contains(testValue) ?? true {
                 do {
                     try execute(statement: switchCaseDecl.statement)
                 } catch JumpType.break {

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -63,6 +63,10 @@ class Interpreter {
             try handleIfStatement(testExpr: testExpr,
                                   consequentStmt: consequentStmt,
                                   alternativeStmt: alternativeStmt)
+        case .switch(let testExpr, let switchCaseDecls, let switchDefaultStmts):
+            try handleSwitchStatement(testExpr: testExpr,
+                                      switchCaseDecls: switchCaseDecls,
+                                      switchDefaultStmts: switchDefaultStmts)
         case .print(let expr):
             try handlePrintStatement(expr: expr)
         case .variableDeclaration(let name, let expr):
@@ -108,6 +112,12 @@ class Interpreter {
         } else if let alternativeStmt {
             try execute(statement: alternativeStmt)
         }
+    }
+
+    private func handleSwitchStatement(testExpr: ResolvedExpression,
+                                       switchCaseDecls: [ResolvedSwitchCaseDeclaration],
+                                       switchDefaultStmts: [ResolvedStatement]?) throws {
+        print("OMFG I GOT HERE")
     }
 
     private func handlePrintStatement(expr: ResolvedExpression) throws {

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -120,9 +120,11 @@ class Interpreter {
         let testValue = try evaluate(expr: testExpr)
 
         for switchCaseDecl in switchCaseDecls {
-            let caseValue = try evaluate(expr: switchCaseDecl.valueExpression)
+            let caseValues = try switchCaseDecl.valueExpressions.map { valueExpr in
+                try evaluate(expr: valueExpr)
+            }
 
-            if caseValue == testValue {
+            if caseValues.contains(testValue) {
                 do {
                     try execute(statement: switchCaseDecl.statement)
                 } catch JumpType.break {

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -117,7 +117,31 @@ class Interpreter {
     private func handleSwitchStatement(testExpr: ResolvedExpression,
                                        switchCaseDecls: [ResolvedSwitchCaseDeclaration],
                                        switchDefaultStmts: [ResolvedStatement]?) throws {
-        print("OMFG I GOT HERE")
+        let testValue = try evaluate(expr: testExpr)
+
+        var foundMatch = false
+        for switchCaseDecl in switchCaseDecls {
+            let caseValue = try evaluate(expr: switchCaseDecl.valueExpression)
+
+            if caseValue == testValue {
+                for statement in switchCaseDecl.statements {
+                    try execute(statement: statement)
+                }
+
+                foundMatch = true
+                break
+            }
+        }
+
+        if foundMatch {
+            return
+        }
+
+        if let switchDefaultStmts {
+            for statement in switchDefaultStmts {
+                try execute(statement: statement)
+            }
+        }
     }
 
     private func handlePrintStatement(expr: ResolvedExpression) throws {

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -63,10 +63,9 @@ class Interpreter {
             try handleIfStatement(testExpr: testExpr,
                                   consequentStmt: consequentStmt,
                                   alternativeStmt: alternativeStmt)
-        case .switch(let testExpr, let switchCaseDecls, let switchDefaultStmts):
+        case .switch(let testExpr, let switchCaseDecls):
             try handleSwitchStatement(testExpr: testExpr,
-                                      switchCaseDecls: switchCaseDecls,
-                                      switchDefaultStmts: switchDefaultStmts)
+                                      switchCaseDecls: switchCaseDecls)
         case .print(let expr):
             try handlePrintStatement(expr: expr)
         case .variableDeclaration(let name, let expr):
@@ -115,16 +114,15 @@ class Interpreter {
     }
 
     private func handleSwitchStatement(testExpr: ResolvedExpression,
-                                       switchCaseDecls: [ResolvedSwitchCaseDeclaration],
-                                       switchDefaultStmts: [ResolvedStatement]?) throws {
+                                       switchCaseDecls: [ResolvedSwitchCaseDeclaration]) throws {
         let testValue = try evaluate(expr: testExpr)
 
         for switchCaseDecl in switchCaseDecls {
-            let caseValues = try switchCaseDecl.valueExpressions.map { valueExpr in
+            let caseValues = try switchCaseDecl.valueExpressions?.map { valueExpr in
                 try evaluate(expr: valueExpr)
             }
 
-            if caseValues.contains(testValue) {
+            if caseValues == nil || caseValues!.contains(testValue) {
                 do {
                     try execute(statement: switchCaseDecl.statement)
                 } catch JumpType.break {
@@ -132,12 +130,6 @@ class Interpreter {
                 }
 
                 return
-            }
-        }
-
-        if let switchDefaultStmts {
-            for statement in switchDefaultStmts {
-                try execute(statement: statement)
             }
         }
     }

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -114,27 +114,26 @@ class Interpreter {
         }
     }
 
+//    var foo = 42;
+//    var bar = 21;
+//    switch (bar) { case 21: if (foo > bar) { break; } foo = 0; }
     private func handleSwitchStatement(testExpr: ResolvedExpression,
                                        switchCaseDecls: [ResolvedSwitchCaseDeclaration],
                                        switchDefaultStmts: [ResolvedStatement]?) throws {
         let testValue = try evaluate(expr: testExpr)
 
-        var foundMatch = false
         for switchCaseDecl in switchCaseDecls {
             let caseValue = try evaluate(expr: switchCaseDecl.valueExpression)
 
             if caseValue == testValue {
-                for statement in switchCaseDecl.statements {
-                    try execute(statement: statement)
+                do {
+                    try execute(statement: switchCaseDecl.statement)
+                } catch JumpType.break {
+                    break
                 }
 
-                foundMatch = true
-                break
+                return
             }
-        }
-
-        if foundMatch {
-            return
         }
 
         if let switchDefaultStmts {

--- a/slox/ParseError.swift
+++ b/slox/ParseError.swift
@@ -17,6 +17,11 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
     case missingClosingBrace(Token)
     case missingOpenParenForIfStatement(Token)
     case missingCloseParenForIfStatement(Token)
+    case missingOpenParenForSwitchStatement(Token)
+    case missingCloseParenForSwitchStatement(Token)
+    case missingOpenBraceBeforeSwitchBody(Token)
+    case missingCaseOrDefault(Token)
+    case missingColon(Token)
     case missingOpenParenForWhileStatement(Token)
     case missingCloseParenForWhileStatement(Token)
     case missingOpenParenForForStatement(Token)
@@ -61,6 +66,16 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(token.line)] Error: expected left parenthesis after `if`"
         case .missingCloseParenForIfStatement(let token):
             return "[Line \(token.line)] Error: expected right parenthesis after `if` condition"
+        case .missingOpenParenForSwitchStatement(let token):
+            return "[Line \(token.line)] Error: expected left parenthesis after `switch`"
+        case .missingCloseParenForSwitchStatement(let token):
+            return "[Line \(token.line)] Error: expected right parenthesis after `switch` condition"
+        case .missingOpenBraceBeforeSwitchBody(let token):
+            return "[Line \(token.line)] Error: expected open brace before switch body"
+        case .missingCaseOrDefault(let token):
+            return "[Line \(token.line)] Error: expected `case` or `default` inside `switch` body"
+        case .missingColon(let token):
+            return "[Line \(token.line)] Error: colon required after `case` and `default`"
         case .missingOpenParenForWhileStatement(let token):
             return "[Line \(token.line)] Error: expected left parenthesis after `while`"
         case .missingCloseParenForWhileStatement(let token):

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -390,7 +390,7 @@ struct Parser {
         }
 
         var statements: [Statement] = []
-        while !currentTokenMatches(type: .default) && !currentTokenMatches(type: .rightBrace) {
+        while !currentTokenMatches(type: .case) && !currentTokenMatches(type: .default) && !currentTokenMatches(type: .rightBrace) {
             let statement = try parseStatement()
             statements.append(statement)
         }

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -391,11 +391,11 @@ struct Parser {
 
         var statements: [Statement] = []
         while !currentTokenMatches(type: .case) && !currentTokenMatches(type: .default) && !currentTokenMatches(type: .rightBrace) {
-            let statement = try parseStatement()
+            let statement = try parseDeclaration()
             statements.append(statement)
         }
 
-        return SwitchCaseDeclaration(valueExpression: valueExpr, statements: statements)
+        return SwitchCaseDeclaration(valueExpression: valueExpr, statement: .block(statements))
     }
 
     mutating private func parseSwitchDefaultDecl() throws -> [Statement] {
@@ -409,7 +409,7 @@ struct Parser {
 
         var statements: [Statement] = []
         while !currentTokenMatches(type: .rightBrace) {
-            let statement = try parseStatement()
+            let statement = try parseDeclaration()
             statements.append(statement)
         }
 

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -409,7 +409,7 @@ struct Parser {
         }
 
         var statements: [Statement] = []
-        while !currentTokenMatches(type: .rightBrace) {
+        while !currentTokenMatches(type: .rightBrace) && currentToken.type != .eof {
             let statement = try parseDeclaration()
             statements.append(statement)
         }

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -366,16 +366,16 @@ struct Parser {
             switchCaseDecls.append(switchCaseDecl)
         }
 
-        var switchDefaultDecl: [Statement]? = nil
         if currentTokenMatches(type: .default) {
-            switchDefaultDecl = try parseSwitchDefaultDecl()
+            let switchDefaultCaseDecl = try parseSwitchDefaultDecl()
+            switchCaseDecls.append(switchDefaultCaseDecl)
         }
 
         guard currentTokenMatchesAny(types: [.rightBrace]) else {
             throw ParseError.missingClosingBrace(currentToken)
         }
 
-        return .switch(switchExpr, switchCaseDecls, switchDefaultDecl)
+        return .switch(switchExpr, switchCaseDecls)
     }
 
     mutating private func parseSwitchCaseDeclaration() throws -> SwitchCaseDeclaration {
@@ -399,7 +399,7 @@ struct Parser {
         return SwitchCaseDeclaration(valueExpressions: valueExprs, statement: .block(statements))
     }
 
-    mutating private func parseSwitchDefaultDecl() throws -> [Statement] {
+    mutating private func parseSwitchDefaultDecl() throws -> SwitchCaseDeclaration {
         guard currentTokenMatchesAny(types: [.default]) else {
             throw ParseError.missingCaseOrDefault(currentToken)
         }
@@ -414,7 +414,8 @@ struct Parser {
             statements.append(statement)
         }
 
-        return statements
+        let switchCaseDecl = SwitchCaseDeclaration(statement: .block(statements))
+        return switchCaseDecl
     }
 
     mutating private func parsePrintStatement() throws -> Statement? {

--- a/slox/ResolvedStatement.swift
+++ b/slox/ResolvedStatement.swift
@@ -8,6 +8,7 @@
 indirect enum ResolvedStatement: Equatable {
     case expression(ResolvedExpression)
     case `if`(ResolvedExpression, ResolvedStatement, ResolvedStatement?)
+    case `switch`(ResolvedExpression, [ResolvedSwitchCaseDeclaration], [ResolvedStatement]?)
     case print(ResolvedExpression)
     case variableDeclaration(Token, ResolvedExpression?)
     case block([ResolvedStatement])

--- a/slox/ResolvedStatement.swift
+++ b/slox/ResolvedStatement.swift
@@ -8,7 +8,7 @@
 indirect enum ResolvedStatement: Equatable {
     case expression(ResolvedExpression)
     case `if`(ResolvedExpression, ResolvedStatement, ResolvedStatement?)
-    case `switch`(ResolvedExpression, [ResolvedSwitchCaseDeclaration], [ResolvedStatement]?)
+    case `switch`(ResolvedExpression, [ResolvedSwitchCaseDeclaration])
     case print(ResolvedExpression)
     case variableDeclaration(Token, ResolvedExpression?)
     case block([ResolvedStatement])

--- a/slox/ResolvedSwitchCaseDeclaration.swift
+++ b/slox/ResolvedSwitchCaseDeclaration.swift
@@ -1,0 +1,11 @@
+//
+//  ResolvedSwitchCaseDeclaration.swift
+//  slox
+//
+//  Created by Danielle Kefford on 4/26/24.
+//
+
+struct ResolvedSwitchCaseDeclaration: Equatable {
+    var valueExpression: ResolvedExpression
+    var statements: [ResolvedStatement]
+}

--- a/slox/ResolvedSwitchCaseDeclaration.swift
+++ b/slox/ResolvedSwitchCaseDeclaration.swift
@@ -7,5 +7,5 @@
 
 struct ResolvedSwitchCaseDeclaration: Equatable {
     var valueExpression: ResolvedExpression
-    var statements: [ResolvedStatement]
+    var statement: ResolvedStatement
 }

--- a/slox/ResolvedSwitchCaseDeclaration.swift
+++ b/slox/ResolvedSwitchCaseDeclaration.swift
@@ -6,6 +6,6 @@
 //
 
 struct ResolvedSwitchCaseDeclaration: Equatable {
-    var valueExpression: ResolvedExpression
+    var valueExpressions: [ResolvedExpression]
     var statement: ResolvedStatement
 }

--- a/slox/ResolvedSwitchCaseDeclaration.swift
+++ b/slox/ResolvedSwitchCaseDeclaration.swift
@@ -6,6 +6,6 @@
 //
 
 struct ResolvedSwitchCaseDeclaration: Equatable {
-    var valueExpressions: [ResolvedExpression]
+    var valueExpressions: [ResolvedExpression]?
     var statement: ResolvedStatement
 }

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -306,9 +306,9 @@ struct Resolver {
 
     mutating private func handleSwitchCaseDeclaration(switchCaseDecl: SwitchCaseDeclaration) throws -> ResolvedSwitchCaseDeclaration {
         let resolvedValueExpr = try resolve(expression: switchCaseDecl.valueExpression)
-        let resolvedStmts = try resolve(statements: switchCaseDecl.statements)
+        let resolvedStmt = try resolve(statement: switchCaseDecl.statement)
 
-        return ResolvedSwitchCaseDeclaration(valueExpression: resolvedValueExpr, statements: resolvedStmts)
+        return ResolvedSwitchCaseDeclaration(valueExpression: resolvedValueExpr, statement: resolvedStmt)
     }
 
     mutating private func handlePrintStatement(expr: Expression) throws -> ResolvedStatement {

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -72,10 +72,9 @@ struct Resolver {
             return try handleExpressionStatement(expr: expr)
         case .if(let testExpr, let consequentStmt, let alternativeStmt):
             return try handleIf(testExpr: testExpr, consequentStmt: consequentStmt, alternativeStmt: alternativeStmt)
-        case .switch(let testExpr, let switchCaseDecls, let switchDefaultStmts):
+        case .switch(let testExpr, let switchCaseDecls):
             return try handleSwitch(testExpr: testExpr,
-                                    switchCaseDecls: switchCaseDecls,
-                                    switchDefaultStmts: switchDefaultStmts)
+                                    switchCaseDecls: switchCaseDecls)
         case .print(let expr):
             return try handlePrintStatement(expr: expr)
         case .return(let returnToken, let expr):
@@ -287,8 +286,7 @@ struct Resolver {
     }
 
     mutating private func handleSwitch(testExpr: Expression,
-                                       switchCaseDecls: [SwitchCaseDeclaration],
-                                       switchDefaultStmts: [Statement]?) throws -> ResolvedStatement {
+                                       switchCaseDecls: [SwitchCaseDeclaration]) throws -> ResolvedStatement {
         let previousJumpableType = currentJumpableType
         currentJumpableType = .switch
         defer {
@@ -304,16 +302,11 @@ struct Resolver {
             try handleSwitchCaseDeclaration(switchCaseDecl: switchCaseDecl)
         }
 
-        var resolvedSwitchDefaultStmts: [ResolvedStatement]? = nil
-        if let switchDefaultStmts {
-            resolvedSwitchDefaultStmts = try resolve(statements: switchDefaultStmts)
-        }
-
-        return .switch(resolvedTestExpr, resolvedSwitchCaseDecls, resolvedSwitchDefaultStmts)
+        return .switch(resolvedTestExpr, resolvedSwitchCaseDecls)
     }
 
     mutating private func handleSwitchCaseDeclaration(switchCaseDecl: SwitchCaseDeclaration) throws -> ResolvedSwitchCaseDeclaration {
-        let resolvedValueExprs = try switchCaseDecl.valueExpressions.map { valueExpr in
+        let resolvedValueExprs = try switchCaseDecl.valueExpressions?.map { valueExpr in
             try resolve(expression: valueExpr)
         }
 

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -316,6 +316,12 @@ struct Resolver {
         let resolvedValueExprs = try switchCaseDecl.valueExpressions.map { valueExpr in
             try resolve(expression: valueExpr)
         }
+
+        guard case .block(let statements) = switchCaseDecl.statement,
+              statements.count > 0 else {
+            throw ResolverError.switchMustHaveAtLeastOneStatementPerCaseOrDefault
+        }
+
         let resolvedStmt = try resolve(statement: switchCaseDecl.statement)
 
         return ResolvedSwitchCaseDeclaration(valueExpressions: resolvedValueExprs, statement: resolvedStmt)

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -312,10 +312,12 @@ struct Resolver {
     }
 
     mutating private func handleSwitchCaseDeclaration(switchCaseDecl: SwitchCaseDeclaration) throws -> ResolvedSwitchCaseDeclaration {
-        let resolvedValueExpr = try resolve(expression: switchCaseDecl.valueExpression)
+        let resolvedValueExprs = try switchCaseDecl.valueExpressions.map { valueExpr in
+            try resolve(expression: valueExpr)
+        }
         let resolvedStmt = try resolve(statement: switchCaseDecl.statement)
 
-        return ResolvedSwitchCaseDeclaration(valueExpression: resolvedValueExpr, statement: resolvedStmt)
+        return ResolvedSwitchCaseDeclaration(valueExpressions: resolvedValueExprs, statement: resolvedStmt)
     }
 
     mutating private func handlePrintStatement(expr: Expression) throws -> ResolvedStatement {

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -299,6 +299,10 @@ struct Resolver {
         }
 
         let resolvedTestExpr = try resolve(expression: testExpr)
+
+        guard switchCaseDecls.count > 0 else {
+            throw ResolverError.switchMustHaveAtLeastOneCaseOrDefault
+        }
         let resolvedSwitchCaseDecls = try switchCaseDecls.map { switchCaseDecl in
             try handleSwitchCaseDeclaration(switchCaseDecl: switchCaseDecl)
         }

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -200,12 +200,9 @@ struct Resolver {
                                                 methods: [Statement],
                                                 staticMethods: [Statement]) throws -> ResolvedStatement {
         let previousClassType = currentClassType
-        let previousLoopType = currentLoopType
         currentClassType = .enum
-        currentLoopType = .none
         defer {
             currentClassType = previousClassType
-            currentLoopType = previousLoopType
         }
 
         try declareVariable(name: nameToken.lexeme)

--- a/slox/ResolverError.swift
+++ b/slox/ResolverError.swift
@@ -18,7 +18,7 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
     case classCannotInheritFromItself
     case cannotReferenceSuperOutsideClass
     case cannotReferenceSuperWithoutSubclassing
-    case cannotBreakOutsideLoop
+    case cannotBreakOutsideLoopOrSwitch
     case cannotContinueOutsideLoop
     case functionsMustHaveAParameterList
     case cannotUseSplatOperatorOutOfContext
@@ -46,8 +46,8 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
             return "Cannot use `super` from outside a class"
         case .cannotReferenceSuperWithoutSubclassing:
             return "Cannot use `super` without subclassing"
-        case .cannotBreakOutsideLoop:
-            return "Can only `break` from inside a `while` or `for` loop"
+        case .cannotBreakOutsideLoopOrSwitch:
+            return "Can only `break` from inside a loop or switch statement"
         case .cannotContinueOutsideLoop:
             return "Can only `continue` from inside a `while` or `for` loop"
         case .functionsMustHaveAParameterList:

--- a/slox/ResolverError.swift
+++ b/slox/ResolverError.swift
@@ -23,6 +23,7 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
     case functionsMustHaveAParameterList
     case cannotUseSplatOperatorOutOfContext
     case duplicateCaseNamesNotAllowed(Token)
+    case switchMustHaveAtLeastOneCaseOrDefault
 
     var description: String {
         switch self {
@@ -56,6 +57,8 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
             return "Cannot use splat operator in this context"
         case .duplicateCaseNamesNotAllowed(let token):
             return "Cannot use duplicate case names in enum: \(token.lexeme)"
+        case .switchMustHaveAtLeastOneCaseOrDefault:
+            return "`switch` statement must have at least one `case` or `default` block"
         }
     }
 }

--- a/slox/ResolverError.swift
+++ b/slox/ResolverError.swift
@@ -61,7 +61,7 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
         case .switchMustHaveAtLeastOneCaseOrDefault:
             return "`switch` statement must have at least one `case` or `default` block"
         case .switchMustHaveAtLeastOneStatementPerCaseOrDefault:
-            return "`switch` statement must have at least one `case` or `default` block"
+            return "`Each `case` or `default` block must have at least one statement"
         }
     }
 }

--- a/slox/ResolverError.swift
+++ b/slox/ResolverError.swift
@@ -24,6 +24,7 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
     case cannotUseSplatOperatorOutOfContext
     case duplicateCaseNamesNotAllowed(Token)
     case switchMustHaveAtLeastOneCaseOrDefault
+    case switchMustHaveAtLeastOneStatementPerCaseOrDefault
 
     var description: String {
         switch self {
@@ -58,6 +59,8 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
         case .duplicateCaseNamesNotAllowed(let token):
             return "Cannot use duplicate case names in enum: \(token.lexeme)"
         case .switchMustHaveAtLeastOneCaseOrDefault:
+            return "`switch` statement must have at least one `case` or `default` block"
+        case .switchMustHaveAtLeastOneStatementPerCaseOrDefault:
             return "`switch` statement must have at least one `case` or `default` block"
         }
     }

--- a/slox/Scanner.swift
+++ b/slox/Scanner.swift
@@ -33,7 +33,7 @@ struct Scanner {
         "break": .break,
         "continue": .continue,
         "enum": .enum,
-        "case": .case
+        "case": .case,
         "switch": .switch,
         "default": .default
     ]

--- a/slox/Scanner.swift
+++ b/slox/Scanner.swift
@@ -34,6 +34,8 @@ struct Scanner {
         "continue": .continue,
         "enum": .enum,
         "case": .case
+        "switch": .switch,
+        "default": .default
     ]
 
     init(source: String) {

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -8,7 +8,7 @@
 indirect enum Statement: Equatable {
     case expression(Expression)
     case `if`(Expression, Statement, Statement?)
-    case `switch`(Expression, [SwitchCaseDeclaration], [Statement]?)
+    case `switch`(Expression, [SwitchCaseDeclaration])
     case print(Expression)
     case variableDeclaration(Token, Expression?)
     case block([Statement])

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -8,6 +8,7 @@
 indirect enum Statement: Equatable {
     case expression(Expression)
     case `if`(Expression, Statement, Statement?)
+    case `switch`(Expression, [SwitchCaseDeclaration], [Statement]?)
     case print(Expression)
     case variableDeclaration(Token, Expression?)
     case block([Statement])

--- a/slox/SwitchCaseDeclaration.swift
+++ b/slox/SwitchCaseDeclaration.swift
@@ -1,0 +1,11 @@
+//
+//  SwitchCaseDeclaration.swift
+//  slox
+//
+//  Created by Danielle Kefford on 4/26/24.
+//
+
+struct SwitchCaseDeclaration: Equatable {
+    var valueExpression: Expression
+    var statements: [Statement]
+}

--- a/slox/SwitchCaseDeclaration.swift
+++ b/slox/SwitchCaseDeclaration.swift
@@ -6,6 +6,6 @@
 //
 
 struct SwitchCaseDeclaration: Equatable {
-    var valueExpression: Expression
+    var valueExpressions: [Expression]
     var statement: Statement
 }

--- a/slox/SwitchCaseDeclaration.swift
+++ b/slox/SwitchCaseDeclaration.swift
@@ -6,6 +6,6 @@
 //
 
 struct SwitchCaseDeclaration: Equatable {
-    var valueExpressions: [Expression]
+    var valueExpressions: [Expression]?
     var statement: Statement
 }

--- a/slox/SwitchCaseDeclaration.swift
+++ b/slox/SwitchCaseDeclaration.swift
@@ -7,5 +7,5 @@
 
 struct SwitchCaseDeclaration: Equatable {
     var valueExpression: Expression
-    var statements: [Statement]
+    var statement: Statement
 }

--- a/slox/TokenType.swift
+++ b/slox/TokenType.swift
@@ -64,6 +64,8 @@ enum TokenType: Equatable {
     case `continue`
     case `enum`
     case `case`
+    case `switch`
+    case `default`
 
     case eof
 }

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -1252,4 +1252,38 @@ foo(3)
         let expected: LoxValue = try interpreter.makeString(string: "two, three, or four")
         XCTAssertEqual(actual, expected)
     }
+
+    func testInterpretSwitchStatementWithJustOneCase() throws {
+        let input = """
+var answer = "";
+switch (42) {
+case 42:
+    answer = "forty-two";
+}
+
+answer
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = try interpreter.makeString(string: "forty-two")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretSwitchStatementWithJustDefault() throws {
+        let input = """
+var answer = "";
+switch (42) {
+default:
+    answer = "forty-two";
+}
+
+answer
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = try interpreter.makeString(string: "forty-two")
+        XCTAssertEqual(actual, expected)
+    }
 }

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -1102,4 +1102,132 @@ PizzaSize.medium == ClothingSize.medium;
         let expected: LoxValue = .boolean(false)
         XCTAssertEqual(actual, expected)
     }
+
+    func testInterpretSwitchStatementThatMatchesFirstCase() throws {
+        let input = """
+fun spell(number) {
+    switch (number) {
+    case 1:
+        return "one";
+    case 2:
+        return "two";
+    default:
+        return "unhandled";
+    }
+}
+
+spell(1)
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = try interpreter.makeString(string: "one")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretSwitchStatementThatMatchesAnotherCase() throws {
+        let input = """
+fun spell(number) {
+    switch (number) {
+    case 1:
+        return "one";
+    case 2:
+        return "two";
+    default:
+        return "unhandled";
+    }
+}
+
+spell(2)
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = try interpreter.makeString(string: "two")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretSwitchStatementThatFallsThroughToDefaultCase() throws {
+        let input = """
+fun spell(number) {
+    switch (number) {
+    case 1:
+        return "one";
+    case 2:
+        return "two";
+    default:
+        return "unhandled";
+    }
+}
+
+spell(3)
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = try interpreter.makeString(string: "unhandled")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretSwitchStatementWithACaseThatHasMultipleStatements() throws {
+        let input = """
+var answer = "";
+switch (42) {
+case 41:
+    answer += "not ";
+    answer += "the ";
+    answer += "answer";
+case 42:
+    answer += "forty-";
+    answer += "two";
+default:
+    answer += "unhandled";
+}
+
+answer
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = try interpreter.makeString(string: "forty-two")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInterpretSwitchStatementWithACaseThatDeclaresAVariable() throws {
+        let input = """
+switch (42) {
+case 42:
+    var answer = "forty-two";
+}
+
+answer
+"""
+
+        let interpreter = Interpreter()
+        let expectedError = RuntimeError.undefinedVariable("answer")
+        XCTAssertThrowsError(try interpreter.interpretRepl(source: input)!) { actualError in
+            XCTAssertEqual(actualError as! RuntimeError, expectedError)
+        }
+    }
+
+    func testInterpretSwitchStatementWithACaseThatHasABreakStatement() throws {
+        let input = """
+var answer = "forty-two";
+switch (42) {
+case 42:
+    if (true) {
+        break;
+    }
+    // We should never get here!!!
+    answer = "NEVER!";
+}
+
+answer
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = try interpreter.makeString(string: "forty-two")
+        XCTAssertEqual(actual, expected)
+    }
 }

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -1230,4 +1230,26 @@ answer
         let expected: LoxValue = try interpreter.makeString(string: "forty-two")
         XCTAssertEqual(actual, expected)
     }
+
+    func testInterpretSwitchStatementWithACaseThatHasAListOfTestValues() throws {
+        let input = """
+fun foo(number) {
+    switch (number) {
+    case 1:
+        return "one";
+    case 2, 3, 4:
+        return "two, three, or four";
+    default:
+        return "unhandled";
+    }
+}
+
+foo(3)
+"""
+
+        let interpreter = Interpreter()
+        let actual = try interpreter.interpretRepl(source: input)
+        let expected: LoxValue = try interpreter.makeString(string: "two, three, or four")
+        XCTAssertEqual(actual, expected)
+    }
 }

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -1893,4 +1893,31 @@ final class ParserTests: XCTestCase {
             XCTAssertEqual(actualError as! ParseError, expectedError)
         }
     }
+
+    func testParseSwitchStatementWithStatementInsteadOfCase() throws {
+        // switch (foo) {
+        //     print "boom!";
+        // }
+        let tokens: [Token] = [
+            Token(type: .switch, lexeme: "switch", line: 1),
+            Token(type: .leftParen, lexeme: "(", line: 1),
+            Token(type: .identifier, lexeme: "foo", line: 1),
+            Token(type: .rightParen, lexeme: ")", line: 1),
+            Token(type: .leftBrace, lexeme: "{", line: 1),
+
+            Token(type: .print, lexeme: "print", line: 2),
+            Token(type: .string, lexeme: "\"boom!\"", line: 2),
+            Token(type: .semicolon, lexeme: ";", line: 2),
+
+            Token(type: .rightBrace, lexeme: "}", line: 3),
+            Token(type: .eof, lexeme: "", line: 3),
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let lastToken = Token(type: .print, lexeme: "print", line: 2)
+        let expectedError = ParseError.missingCaseOrDefault(lastToken)
+        XCTAssertThrowsError(try parser.parse()) { actualError in
+            XCTAssertEqual(actualError as! ParseError, expectedError)
+        }
+    }
 }

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -1656,4 +1656,240 @@ final class ParserTests: XCTestCase {
         ]
         XCTAssertEqual(actual, expected)
     }
+
+    func testParseSwitchStatement() throws {
+        // switch (foo) {
+        // case 1:
+        //     print "one";
+        // case 2, 3, 4:
+        //     print "two";
+        //     print "three";
+        //     print "or four";
+        // default:
+        //     print "unhandled";
+        // }
+        let tokens: [Token] = [
+            Token(type: .switch, lexeme: "switch", line: 1),
+            Token(type: .leftParen, lexeme: "(", line: 1),
+            Token(type: .identifier, lexeme: "foo", line: 1),
+            Token(type: .rightParen, lexeme: ")", line: 1),
+            Token(type: .leftBrace, lexeme: "{", line: 1),
+
+            Token(type: .case, lexeme: "case", line: 2),
+            Token(type: .int, lexeme: "1", line: 2),
+            Token(type: .colon, lexeme: ":", line: 2),
+
+            Token(type: .print, lexeme: "print", line: 3),
+            Token(type: .string, lexeme: "\"one\"", line: 3),
+            Token(type: .semicolon, lexeme: ";", line: 3),
+
+            Token(type: .case, lexeme: "case", line: 4),
+            Token(type: .int, lexeme: "2", line: 4),
+            Token(type: .comma, lexeme: ",", line: 4),
+            Token(type: .int, lexeme: "3", line: 4),
+            Token(type: .comma, lexeme: ",", line: 4),
+            Token(type: .int, lexeme: "4", line: 4),
+            Token(type: .colon, lexeme: ":", line: 4),
+
+            Token(type: .print, lexeme: "print", line: 5),
+            Token(type: .string, lexeme: "\"two\"", line: 5),
+            Token(type: .semicolon, lexeme: ";", line: 5),
+
+            Token(type: .print, lexeme: "print", line: 6),
+            Token(type: .string, lexeme: "\"three\"", line: 6),
+            Token(type: .semicolon, lexeme: ";", line: 6),
+
+            Token(type: .print, lexeme: "print", line: 7),
+            Token(type: .string, lexeme: "\"or four\"", line: 7),
+            Token(type: .semicolon, lexeme: ";", line: 7),
+
+            Token(type: .default, lexeme: "default", line: 8),
+            Token(type: .colon, lexeme: ":", line: 8),
+
+            Token(type: .print, lexeme: "print", line: 9),
+            Token(type: .string, lexeme: "\"unhandled\"", line: 9),
+            Token(type: .semicolon, lexeme: ";", line: 9),
+
+            Token(type: .rightBrace, lexeme: "}", line: 10),
+            Token(type: .eof, lexeme: "", line: 10),
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let actual = try parser.parse()
+        let expected: [Statement] = [
+            .switch(
+                .variable(Token(type: .identifier, lexeme: "foo", line: 1)),
+                [
+                    SwitchCaseDeclaration(
+                        valueExpressions: [
+                            .literal(.int(1))
+                        ],
+                        statement: .block([
+                            .print(.string(Token(type: .string, lexeme: "\"one\"", line: 3)))
+                        ])),
+                    SwitchCaseDeclaration(
+                        valueExpressions: [
+                            .literal(.int(2)),
+                            .literal(.int(3)),
+                            .literal(.int(4)),
+                        ],
+                        statement: .block([
+                            .print(.string(Token(type: .string, lexeme: "\"two\"", line: 5))),
+                            .print(.string(Token(type: .string, lexeme: "\"three\"", line: 6))),
+                            .print(.string(Token(type: .string, lexeme: "\"or four\"", line: 7)))
+                        ])),
+                ],
+                [
+                    .print(.string(Token(type: .string, lexeme: "\"unhandled\"", line: 9))),
+                ])
+        ]
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testParseSwitchStatementMissingOpenParen() throws {
+        // switch foo {
+        // default:
+        //     print "boom!";
+        // }
+        let tokens: [Token] = [
+            Token(type: .switch, lexeme: "switch", line: 1),
+            Token(type: .identifier, lexeme: "foo", line: 1),
+            Token(type: .leftBrace, lexeme: "{", line: 1),
+
+            Token(type: .default, lexeme: "default", line: 2),
+            Token(type: .colon, lexeme: ":", line: 2),
+
+            Token(type: .print, lexeme: "print", line: 3),
+            Token(type: .string, lexeme: "\"boom!\"", line: 3),
+            Token(type: .semicolon, lexeme: ";", line: 3),
+
+            Token(type: .rightBrace, lexeme: "}", line: 4),
+            Token(type: .eof, lexeme: "", line: 4),
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let lastToken = Token(type: .identifier, lexeme: "foo", line: 1)
+        let expectedError = ParseError.missingOpenParenForSwitchStatement(lastToken)
+        XCTAssertThrowsError(try parser.parse()) { actualError in
+            XCTAssertEqual(actualError as! ParseError, expectedError)
+        }
+    }
+
+    func testParseSwitchStatementMissingCloseParen() throws {
+        // switch (foo {
+        // default:
+        //     print "boom!";
+        // }
+        let tokens: [Token] = [
+            Token(type: .switch, lexeme: "switch", line: 1),
+            Token(type: .leftParen, lexeme: "(", line: 1),
+            Token(type: .identifier, lexeme: "foo", line: 1),
+            Token(type: .leftBrace, lexeme: "{", line: 1),
+
+            Token(type: .default, lexeme: "default", line: 2),
+            Token(type: .colon, lexeme: ":", line: 2),
+
+            Token(type: .print, lexeme: "print", line: 3),
+            Token(type: .string, lexeme: "\"boom!\"", line: 3),
+            Token(type: .semicolon, lexeme: ";", line: 3),
+
+            Token(type: .rightBrace, lexeme: "}", line: 4),
+            Token(type: .eof, lexeme: "", line: 4),
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let lastToken = Token(type: .leftBrace, lexeme: "{", line: 1)
+        let expectedError = ParseError.missingCloseParenForSwitchStatement(lastToken)
+        XCTAssertThrowsError(try parser.parse()) { actualError in
+            XCTAssertEqual(actualError as! ParseError, expectedError)
+        }
+    }
+
+    func testParseSwitchStatementMissingOpenBrace() throws {
+        // switch (foo)
+        // default:
+        //     print "boom!";
+        // }
+        let tokens: [Token] = [
+            Token(type: .switch, lexeme: "switch", line: 1),
+            Token(type: .leftParen, lexeme: "(", line: 1),
+            Token(type: .identifier, lexeme: "foo", line: 1),
+            Token(type: .rightParen, lexeme: ")", line: 1),
+
+            Token(type: .default, lexeme: "default", line: 2),
+            Token(type: .colon, lexeme: ":", line: 2),
+
+            Token(type: .print, lexeme: "print", line: 3),
+            Token(type: .string, lexeme: "\"boom!\"", line: 3),
+            Token(type: .semicolon, lexeme: ";", line: 3),
+
+            Token(type: .rightBrace, lexeme: "}", line: 4),
+            Token(type: .eof, lexeme: "", line: 4),
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let lastToken = Token(type: .default, lexeme: "default", line: 2)
+        let expectedError = ParseError.missingOpenBraceBeforeSwitchBody(lastToken)
+        XCTAssertThrowsError(try parser.parse()) { actualError in
+            XCTAssertEqual(actualError as! ParseError, expectedError)
+        }
+    }
+
+    func testParseSwitchStatementMissingColon() throws {
+        // switch (foo) {
+        // default
+        //     print "boom!";
+        // }
+        let tokens: [Token] = [
+            Token(type: .switch, lexeme: "switch", line: 1),
+            Token(type: .leftParen, lexeme: "(", line: 1),
+            Token(type: .identifier, lexeme: "foo", line: 1),
+            Token(type: .rightParen, lexeme: ")", line: 1),
+            Token(type: .leftBrace, lexeme: "{", line: 1),
+
+            Token(type: .default, lexeme: "default", line: 2),
+
+            Token(type: .print, lexeme: "print", line: 3),
+            Token(type: .string, lexeme: "\"boom!\"", line: 3),
+            Token(type: .semicolon, lexeme: ";", line: 3),
+
+            Token(type: .rightBrace, lexeme: "}", line: 4),
+            Token(type: .eof, lexeme: "", line: 4),
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let lastToken = Token(type: .print, lexeme: "print", line: 3)
+        let expectedError = ParseError.missingColon(lastToken)
+        XCTAssertThrowsError(try parser.parse()) { actualError in
+            XCTAssertEqual(actualError as! ParseError, expectedError)
+        }
+    }
+
+    func testParseSwitchStatementMissingCloseBrace() throws {
+        // switch (foo) {
+        // default:
+        //     print "boom!";
+        let tokens: [Token] = [
+            Token(type: .switch, lexeme: "switch", line: 1),
+            Token(type: .leftParen, lexeme: "(", line: 1),
+            Token(type: .identifier, lexeme: "foo", line: 1),
+            Token(type: .rightParen, lexeme: ")", line: 1),
+            Token(type: .leftBrace, lexeme: "{", line: 1),
+
+            Token(type: .default, lexeme: "default", line: 2),
+            Token(type: .colon, lexeme: ":", line: 2),
+
+            Token(type: .print, lexeme: "print", line: 3),
+            Token(type: .string, lexeme: "\"boom!\"", line: 3),
+            Token(type: .semicolon, lexeme: ";", line: 3),
+            Token(type: .eof, lexeme: "", line: 3),
+        ]
+
+        var parser = Parser(tokens: tokens)
+        let lastToken = Token(type: .eof, lexeme: "", line: 3)
+        let expectedError = ParseError.missingClosingBrace(lastToken)
+        XCTAssertThrowsError(try parser.parse()) { actualError in
+            XCTAssertEqual(actualError as! ParseError, expectedError)
+        }
+    }
 }

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -1738,9 +1738,10 @@ final class ParserTests: XCTestCase {
                             .print(.string(Token(type: .string, lexeme: "\"three\"", line: 6))),
                             .print(.string(Token(type: .string, lexeme: "\"or four\"", line: 7)))
                         ])),
-                ],
-                [
-                    .print(.string(Token(type: .string, lexeme: "\"unhandled\"", line: 9))),
+                    SwitchCaseDeclaration(
+                        statement: .block([
+                            .print(.string(Token(type: .string, lexeme: "\"unhandled\"", line: 9))),
+                        ])),
                 ])
         ]
         XCTAssertEqual(actual, expected)

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -483,7 +483,7 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.cannotBreakOutsideLoop
+        let expectedError = ResolverError.cannotBreakOutsideLoopOrSwitch
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -516,7 +516,7 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.cannotBreakOutsideLoop
+        let expectedError = ResolverError.cannotBreakOutsideLoopOrSwitch
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -576,7 +576,7 @@ final class ResolverTests: XCTestCase {
         // switch (42) {
         // }
         let statements: [Statement] = [
-            .switch(.literal(.int(42)), [], [])
+            .switch(.literal(.int(42)), [])
         ]
 
         var resolver = Resolver()
@@ -599,8 +599,7 @@ final class ResolverTests: XCTestCase {
                             .literal(.int(42))
                         ],
                         statement: .block([]))
-                ],
-                [])
+                ])
         ]
 
         var resolver = Resolver()

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -585,4 +585,28 @@ final class ResolverTests: XCTestCase {
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
     }
+
+    func testResolveSwitchWithEmptyCase() throws {
+        // switch (42) {
+        // case 42:
+        // }
+        let statements: [Statement] = [
+            .switch(
+                .literal(.int(42)),
+                [
+                    SwitchCaseDeclaration(
+                        valueExpressions: [
+                            .literal(.int(42))
+                        ],
+                        statement: .block([]))
+                ],
+                [])
+        ]
+
+        var resolver = Resolver()
+        let expectedError = ResolverError.switchMustHaveAtLeastOneStatementPerCaseOrDefault
+        XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
+            XCTAssertEqual(actualError as! ResolverError, expectedError)
+        }
+    }
 }

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -571,4 +571,18 @@ final class ResolverTests: XCTestCase {
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
     }
+
+    func testResolveSwitchWithEmptyBody() throws {
+        // switch (42) {
+        // }
+        let statements: [Statement] = [
+            .switch(.literal(.int(42)), [], [])
+        ]
+
+        var resolver = Resolver()
+        let expectedError = ResolverError.switchMustHaveAtLeastOneCaseOrDefault
+        XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
+            XCTAssertEqual(actualError as! ResolverError, expectedError)
+        }
+    }
 }


### PR DESCRIPTION
The following changes were made in this PR:

* There are two new token types, `.switch` and `.default`, and the scanner now looks for these token types. `.case` had already been introduced with enums in the previous PR.
* There is a new struct, `SwitchCaseDeclaration`, which houses the optional list of test expressions and associated `block` statement containing the list of other statements comprising each case or default block. There is also its resolved analogue, `ResolvedSwitchCaseDeclaration`.
* `Statement` and `ResolvedStatement` have a new case, `switch`, which associates a test expression and a list of `SwitchCaseDeclaration`s and `ResolvedSwitchCaseDeclaration`, respectively.
* There is a new method in the parser, namely `parseSwitchStatement()` to do the obvious. It does some processing itself, as well as defers to two new helper functions, `parseSwitchCaseDeclaration()` and `parseSwitchDefaultDeclaration()`, the latter which creates a new `SwitchCaseDeclaration` with a nil test expression list.
* There are five new cases in `ParseError` which correspond with the various syntax errors that can an will be thrown by the parser.
* The resolver has two new checks:
  * one to insure that there is at least one `case` or `default` inside a `switch`
  * another one to insure that there is at least one statement inside each `case` and/or `default`
* The inner emum, `LoopType` has been renamed to `JumpableType` and includes a new `.enum` case to allow for `break` statements inside `switch` statements.
* `ResolverError` has two new cases corresponding with the resolver checks mentioned above, and a renamed case to reflect that `switch` statements can also have `break`s inside them.
* The interpreter has a new method, `handleSwitchStatement()`. It first evaluates the test expression and then loops over each `SwitchCaseDeclaration`. For the first one that either has a nil list of matching expression values, or contains a value that matches the test one, that corresponding block of statements is executed.
* The README has been updated accordingly.
* The Wordle example was updated to take advantage of the new `switch` statement.