### PR TITLE
Add line numbers to all errors

### DIFF
--- a/slox/Environment.swift
+++ b/slox/Environment.swift
@@ -65,7 +65,7 @@ class Environment: Equatable {
         while i < depth {
             guard let parent = ancestor.enclosingEnvironment else {
                 // NOTA BENE: This should not happen but it _is_ possible
-                throw RuntimeError.couldNotFindAncestorEnvironmentAtDepth(depth)
+                fatalError("Fatal error: could not find ancestor environment at depth \(depth).")
             }
 
             ancestor = parent

--- a/slox/Environment.swift
+++ b/slox/Environment.swift
@@ -25,7 +25,7 @@ class Environment: Equatable {
             return
         }
 
-        throw deriveRuntimeError(nameToken: nameToken)
+        throw RuntimeError.undefinedVariable(nameToken)
     }
 
     func getValueAtDepth(nameToken: Token, depth: Int) throws -> LoxValue {
@@ -35,7 +35,7 @@ class Environment: Equatable {
             return value
         }
 
-        throw deriveRuntimeError(nameToken: nameToken)
+        throw RuntimeError.undefinedVariable(nameToken)
     }
 
     func getValue(nameToken: Token) throws -> LoxValue {
@@ -47,16 +47,7 @@ class Environment: Equatable {
             return try enclosingEnvironment.getValue(nameToken: nameToken)
         }
 
-        throw deriveRuntimeError(nameToken: nameToken)
-    }
-
-    private func deriveRuntimeError(nameToken: Token) -> RuntimeError {
-        switch nameToken.lexeme {
-        case "this":
-            return RuntimeError.thisNotResolved
-        default:
-            return RuntimeError.undefinedVariable(nameToken)
-        }
+        throw RuntimeError.undefinedVariable(nameToken)
     }
 
     private func ancestor(depth: Int) throws -> Environment {

--- a/slox/Environment.swift
+++ b/slox/Environment.swift
@@ -54,8 +54,6 @@ class Environment: Equatable {
         switch nameToken.lexeme {
         case "this":
             return RuntimeError.thisNotResolved
-        case "Dictionary", "Enum", "List", "String":
-            return RuntimeError.standardLibraryFailedToLoad
         default:
             return RuntimeError.undefinedVariable(nameToken)
         }

--- a/slox/Environment.swift
+++ b/slox/Environment.swift
@@ -17,37 +17,48 @@ class Environment: Equatable {
         values[name] = value
     }
 
-    func assignAtDepth(name: String, value: LoxValue, depth: Int) throws {
+    func assignAtDepth(nameToken: Token, value: LoxValue, depth: Int) throws {
         let ancestor = try ancestor(depth: depth)
 
-        if ancestor.values.keys.contains(name) {
-            ancestor.values[name] = value
+        if ancestor.values.keys.contains(nameToken.lexeme) {
+            ancestor.values[nameToken.lexeme] = value
             return
         }
 
-        throw RuntimeError.undefinedVariable(name)
+        throw deriveRuntimeError(nameToken: nameToken)
     }
 
-    func getValueAtDepth(name: String, depth: Int) throws -> LoxValue {
+    func getValueAtDepth(nameToken: Token, depth: Int) throws -> LoxValue {
         let ancestor = try ancestor(depth: depth)
 
-        if let value = ancestor.values[name] {
+        if let value = ancestor.values[nameToken.lexeme] {
             return value
         }
 
-        throw RuntimeError.undefinedVariable(name)
+        throw deriveRuntimeError(nameToken: nameToken)
     }
 
-    func getValue(name: String) throws -> LoxValue {
-        if let value = values[name] {
+    func getValue(nameToken: Token) throws -> LoxValue {
+        if let value = values[nameToken.lexeme] {
             return value
         }
 
         if let enclosingEnvironment {
-            return try enclosingEnvironment.getValue(name: name)
+            return try enclosingEnvironment.getValue(nameToken: nameToken)
         }
 
-        throw RuntimeError.undefinedVariable(name)
+        throw deriveRuntimeError(nameToken: nameToken)
+    }
+
+    private func deriveRuntimeError(nameToken: Token) -> RuntimeError {
+        switch nameToken.lexeme {
+        case "this":
+            return RuntimeError.thisNotResolved
+        case "Dictionary", "Enum", "List", "String":
+            return RuntimeError.standardLibraryFailedToLoad
+        default:
+            return RuntimeError.undefinedVariable(nameToken)
+        }
     }
 
     private func ancestor(depth: Int) throws -> Environment {

--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -9,7 +9,7 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     case binary(Expression, Token, Expression)
     case unary(Token, Expression)
     case literal(Token, LoxValue)
-    case grouping(Expression)
+    case grouping(Token, Expression)
     case variable(Token, Depth)
     case assignment(Token, Expression, Depth)
     case logical(Expression, Token, Expression)
@@ -28,12 +28,14 @@ indirect enum Expression<Depth: Equatable>: Equatable {
 
     var locToken: Token {
         switch self {
-        case .literal(let valueToken, _):
-            return valueToken
         case .binary(_, let operToken, _):
             return operToken
         case .unary(let locToken, _):
             return locToken
+        case .literal(let valueToken, _):
+            return valueToken
+        case .grouping(let leftParenToken, _):
+            return leftParenToken
         case .variable(let nameToken, _):
             return nameToken
         case .assignment(let nameToken, _, _):
@@ -69,8 +71,8 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             return lhsOper == rhsOper && lhsExpr == rhsExpr
         case (.literal(let lhsValueToken, let lhsValue), .literal(let rhsValueToken, let rhsValue)):
             return lhsValueToken == rhsValueToken && lhsValue == rhsValue
-        case (.grouping(let lhsExpr), .grouping(let rhsExpr)):
-            return lhsExpr == rhsExpr
+        case (.grouping(let lhsParenToken, let lhsExpr), .grouping(let rhsParenToken, let rhsExpr)):
+            return lhsParenToken == rhsParenToken && lhsExpr == rhsExpr
         case (.variable(let lhsToken, let lhsDepth), .variable(let rhsToken, let rhsDepth)):
             return lhsToken == rhsToken && lhsDepth == rhsDepth
         case (.assignment(let lhsName, let lhsExpr, let lhsDepth), .assignment(let rhsName, let rhsExpr, let rhsDepth)):

--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -20,10 +20,10 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     case this(Token, Depth)
     case `super`(Token, Token, Depth)
     case string(Token)
-    case list([Expression])
+    case list(Token, [Expression])
     case subscriptGet(Expression, Expression)
     case subscriptSet(Expression, Expression, Expression)
-    case dictionary([(Expression, Expression)])
+    case dictionary(Token, [(Expression, Expression)])
     case splat(Token, Expression)
 
     var locToken: Token {
@@ -56,6 +56,10 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             return superToken
         case .string(let stringToken):
             return stringToken
+        case .list(let leftBracketToken, _):
+            return leftBracketToken
+        case .dictionary(let leftBracketToken, _):
+            return leftBracketToken
         case .splat(let starToken, _):
             return starToken
         default:
@@ -93,13 +97,17 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             return lhsSuper == rhsSuper && lhsMethod == rhsMethod && lhsDepth == rhsDepth
         case (.string(let lhsString), .string(let rhsString)):
             return lhsString == rhsString
-        case (.list(let lhsExprs), .list(let rhsExprs)):
-            return lhsExprs == rhsExprs
+        case (.list(let lhsBracketToken, let lhsExprs), .list(let rhsBracketToken, let rhsExprs)):
+            return lhsBracketToken == rhsBracketToken && lhsExprs == rhsExprs
         case (.subscriptGet(let lhsList, let lhsIdx), .subscriptGet(let rhsList, let rhsIdx)):
             return lhsList == rhsList && lhsIdx == rhsIdx
         case (.subscriptSet(let lhsList, let lhsIdx, let lhsExpr), .subscriptSet(let rhsList, let rhsIdx, let rhsExpr)):
             return lhsList == rhsList && lhsIdx == rhsIdx && lhsExpr == rhsExpr
-        case (.dictionary(let lhsKVPairs), .dictionary(let rhsKVPairs)):
+        case (.dictionary(let lhsBracketToken, let lhsKVPairs), .dictionary(let rhsBracketToken, let rhsKVPairs)):
+            if lhsBracketToken != rhsBracketToken {
+                return false
+            }
+
             if lhsKVPairs.count != rhsKVPairs.count {
                 return false
             }

--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -14,7 +14,7 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     case assignment(Token, Expression, Depth)
     case logical(Expression, Token, Expression)
     case call(Expression, Token, [Expression])
-    case lambda(ParameterList?, [Statement<Depth>])
+    case lambda(Token, ParameterList?, [Statement<Depth>])
     case get(Expression, Token)
     case set(Expression, Token, Expression)
     case this(Token, Depth)
@@ -24,7 +24,7 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     case subscriptGet(Expression, Expression)
     case subscriptSet(Expression, Expression, Expression)
     case dictionary([(Expression, Expression)])
-    case splat(Expression)
+    case splat(Token, Expression)
 
     static func == (lhs: Expression, rhs: Expression) -> Bool {
         switch (lhs, rhs) {
@@ -44,8 +44,8 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             return lhsExpr1 == rhsExpr1 && lhsOper == rhsOper && lhsExpr2 == rhsExpr2
         case (.call(let lhsCallee, let lhsToken, let lhsArgs), .call(let rhsCallee, let rhsToken, let rhsArgs)):
             return lhsCallee == rhsCallee && lhsToken == rhsToken && lhsArgs == rhsArgs
-        case (.lambda(let lhsParams, let lhsBody), .lambda(let rhsParams, let rhsBody)):
-            return lhsParams == rhsParams && lhsBody == rhsBody
+        case (.lambda(let lhsLocToken, let lhsParams, let lhsBody), .lambda(let rhsLocToken, let rhsParams, let rhsBody)):
+            return lhsParams == rhsParams && lhsBody == rhsBody && lhsLocToken == rhsLocToken
         case (.get(let lhsExpr, let lhsName), .get(let rhsExpr, let rhsName)):
             return lhsExpr == rhsExpr && lhsName == rhsName
         case (.set(let lhsExpr1, let lhsName, let lhsExpr2), .set(let rhsExpr1, let rhsName, let rhsExpr2)):
@@ -74,8 +74,8 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             }
 
             return true
-        case (.splat(let lhsList), .splat(let rhsList)):
-            return lhsList == rhsList
+        case (.splat(let lhsStarToken, let lhsList), .splat(let rhsStarToken, let rhsList)):
+            return lhsStarToken == rhsStarToken && lhsList == rhsList
         default:
             return false
         }

--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -15,8 +15,8 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     case logical(Expression, Token, Expression)
     case call(Expression, Token, [Expression])
     case lambda(Token, ParameterList?, [Statement<Depth>])
-    case get(Expression, Token)
-    case set(Expression, Token, Expression)
+    case get(Token, Expression, Token)
+    case set(Token, Expression, Token, Expression)
     case this(Token, Depth)
     case `super`(Token, Token, Depth)
     case string(Token)
@@ -46,10 +46,10 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             return lhsCallee == rhsCallee && lhsToken == rhsToken && lhsArgs == rhsArgs
         case (.lambda(let lhsLocToken, let lhsParams, let lhsBody), .lambda(let rhsLocToken, let rhsParams, let rhsBody)):
             return lhsParams == rhsParams && lhsBody == rhsBody && lhsLocToken == rhsLocToken
-        case (.get(let lhsExpr, let lhsName), .get(let rhsExpr, let rhsName)):
-            return lhsExpr == rhsExpr && lhsName == rhsName
-        case (.set(let lhsExpr1, let lhsName, let lhsExpr2), .set(let rhsExpr1, let rhsName, let rhsExpr2)):
-            return lhsExpr1 == rhsExpr1 && lhsName == rhsName && lhsExpr2 == rhsExpr2
+        case (.get(let lhsLocToken, let lhsExpr, let lhsName), .get(let rhsLocToken, let rhsExpr, let rhsName)):
+            return lhsLocToken == rhsLocToken && lhsExpr == rhsExpr && lhsName == rhsName
+        case (.set(let lhsLocToken, let lhsExpr1, let lhsName, let lhsExpr2), .set(let rhsLocToken, let rhsExpr1, let rhsName, let rhsExpr2)):
+            return lhsLocToken == rhsLocToken && lhsExpr1 == rhsExpr1 && lhsName == rhsName && lhsExpr2 == rhsExpr2
         case (.this(let lhsToken, let lhsDepth), .this(let rhsToken, let rhsDepth)):
             return lhsToken == rhsToken && lhsDepth == rhsDepth
         case (.super(let lhsSuper, let lhsMethod, let lhsDepth), .super(let rhsSuper, let rhsMethod, let rhsDepth)):

--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -21,8 +21,8 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     case `super`(Token, Token, Depth)
     case string(Token)
     case list(Token, [Expression])
-    case subscriptGet(Expression, Expression)
-    case subscriptSet(Expression, Expression, Expression)
+    case subscriptGet(Token, Expression, Expression)
+    case subscriptSet(Token, Expression, Expression, Expression)
     case dictionary(Token, [(Expression, Expression)])
     case splat(Token, Expression)
 
@@ -60,10 +60,12 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             return leftBracketToken
         case .dictionary(let leftBracketToken, _):
             return leftBracketToken
+        case .subscriptGet(let leftBracketToken, _, _):
+            return leftBracketToken
+        case .subscriptSet(let leftBracketToken, _, _, _):
+            return leftBracketToken
         case .splat(let starToken, _):
             return starToken
-        default:
-            return Token(type: .eof, lexeme: "", line: 0)
         }
     }
 
@@ -99,10 +101,10 @@ indirect enum Expression<Depth: Equatable>: Equatable {
             return lhsString == rhsString
         case (.list(let lhsBracketToken, let lhsExprs), .list(let rhsBracketToken, let rhsExprs)):
             return lhsBracketToken == rhsBracketToken && lhsExprs == rhsExprs
-        case (.subscriptGet(let lhsList, let lhsIdx), .subscriptGet(let rhsList, let rhsIdx)):
-            return lhsList == rhsList && lhsIdx == rhsIdx
-        case (.subscriptSet(let lhsList, let lhsIdx, let lhsExpr), .subscriptSet(let rhsList, let rhsIdx, let rhsExpr)):
-            return lhsList == rhsList && lhsIdx == rhsIdx && lhsExpr == rhsExpr
+        case (.subscriptGet(let lhsBracketToken, let lhsList, let lhsIdx), .subscriptGet(let rhsBracketToken, let rhsList, let rhsIdx)):
+            return lhsBracketToken == rhsBracketToken && lhsList == rhsList && lhsIdx == rhsIdx
+        case (.subscriptSet(let lhsBracketToken, let lhsList, let lhsIdx, let lhsExpr), .subscriptSet(let rhsBracketToken, let rhsList, let rhsIdx, let rhsExpr)):
+            return lhsBracketToken == rhsBracketToken && lhsList == rhsList && lhsIdx == rhsIdx && lhsExpr == rhsExpr
         case (.dictionary(let lhsBracketToken, let lhsKVPairs), .dictionary(let rhsBracketToken, let rhsKVPairs)):
             if lhsBracketToken != rhsBracketToken {
                 return false

--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -14,7 +14,7 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     case assignment(Token, Expression, Depth)
     case logical(Expression, Token, Expression)
     case call(Expression, Token, [Expression])
-    case lambda(Token, ParameterList?, [Statement<Depth>])
+    case lambda(Token, ParameterList?, Statement<Depth>)
     case get(Token, Expression, Token)
     case set(Token, Expression, Token, Expression)
     case this(Token, Depth)

--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -8,7 +8,7 @@
 indirect enum Expression<Depth: Equatable>: Equatable {
     case binary(Expression, Token, Expression)
     case unary(Token, Expression)
-    case literal(LoxValue)
+    case literal(Token, LoxValue)
     case grouping(Expression)
     case variable(Token, Depth)
     case assignment(Token, Expression, Depth)
@@ -26,14 +26,49 @@ indirect enum Expression<Depth: Equatable>: Equatable {
     case dictionary([(Expression, Expression)])
     case splat(Token, Expression)
 
+    var locToken: Token {
+        switch self {
+        case .literal(let valueToken, _):
+            return valueToken
+        case .binary(_, let operToken, _):
+            return operToken
+        case .unary(let locToken, _):
+            return locToken
+        case .variable(let nameToken, _):
+            return nameToken
+        case .assignment(let nameToken, _, _):
+            return nameToken
+        case .logical(_, let operToken, _):
+            return operToken
+        case .call(_, let rightParenToken, _):
+            return rightParenToken
+        case .lambda(let locToken, _, _):
+            return locToken
+        case .get(let dotToken, _, _):
+            return dotToken
+        case .set(let dotToken, _, _, _):
+            return dotToken
+        case .this(let thisToken, _):
+            return thisToken
+        case .super(let superToken, _, _):
+            return superToken
+        case .string(let stringToken):
+            return stringToken
+        case .splat(let starToken, _):
+            return starToken
+        default:
+            return Token(type: .eof, lexeme: "", line: 0)
+        }
+    }
+
     static func == (lhs: Expression, rhs: Expression) -> Bool {
         switch (lhs, rhs) {
         case (.binary(let lhsExpr1, let lhsOper, let lhsExpr2), .binary(let rhsExpr1, let rhsOper, let rhsExpr2)):
             return lhsExpr1 == rhsExpr1 && lhsOper == rhsOper && lhsExpr2 == rhsExpr2
         case (.unary(let lhsOper, let lhsExpr), .unary(let rhsOper, let rhsExpr)):
             return lhsOper == rhsOper && lhsExpr == rhsExpr
-        case (.literal(let lhsValue), .literal(let rhsValue)):
-            return lhsValue == rhsValue
+        case (.literal(let lhsValueToken, let lhsValue), .literal(let rhsValueToken, let rhsValue)):
+            return lhsValueToken == rhsValueToken && lhsValue == rhsValue
         case (.grouping(let lhsExpr), .grouping(let rhsExpr)):
             return lhsExpr == rhsExpr
         case (.variable(let lhsToken, let lhsDepth), .variable(let rhsToken, let rhsDepth)):

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -516,7 +516,11 @@ class Interpreter {
         guard let parameterList = actualCallable.parameterList else {
             fatalError()
         }
-        try parameterList.checkArity(argCount: argValues.count)
+        if !parameterList.checkArity(argCount: argValues.count) {
+            throw RuntimeError.wrongArity(calleeExpr.locToken,
+                                          parameterList.normalParameters.count,
+                                          argValues.count)
+        }
 
         do {
             return try actualCallable.call(interpreter: self, args: argValues)

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -341,7 +341,7 @@ class Interpreter {
             return try handleSuperExpression(superToken: superToken, methodToken: methodToken, depth: depth)
         case .string(let stringToken):
             return try handleStringExpression(stringToken: stringToken)
-        case .list(let elements):
+        case .list(_, let elements):
             return try handleListExpression(elements: elements)
         case .subscriptGet(let listExpr, let indexExpr):
             return try handleSubscriptGetExpression(collectionExpr: listExpr, indexExpr: indexExpr)
@@ -351,7 +351,7 @@ class Interpreter {
                                                     valueExpr: valueExpr)
         case .splat(_, let listExpr):
             return try handleSplatExpression(listExpr: listExpr)
-        case .dictionary(let kvPairs):
+        case .dictionary(_, let kvPairs):
             return try handleDictionary(kvExprPairs: kvPairs)
         }
     }

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -148,8 +148,9 @@ class Interpreter {
         environment.define(name: nameToken.lexeme, value: .nil)
 
         let superclass = try superclassExpr.map { superclassExpr in
-            guard case .instance(let superclass as LoxClass) = try evaluate(expr: superclassExpr) else {
-                throw RuntimeError.superclassMustBeAClass
+            guard case .instance(let superclass as LoxClass) = try evaluate(expr: superclassExpr),
+                  !(superclass is LoxEnum) else {
+                throw RuntimeError.superclassMustBeAClass(superclassExpr.locToken)
             }
 
             environment = Environment(enclosingEnvironment: environment);
@@ -569,7 +570,7 @@ class Interpreter {
 
     private func handleSuperExpression(superToken: Token, methodToken: Token, depth: Int) throws -> LoxValue {
         guard case .instance(let superclass as LoxClass) = try environment.getValueAtDepth(nameToken: superToken, depth: depth) else {
-            throw RuntimeError.superclassMustBeAClass
+            fatalError("unable to find superclass at depth, \(depth)")
         }
 
         let dummyThisToken = Token(type: .identifier, lexeme: "this", line: 0)

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -59,7 +59,7 @@ class Interpreter {
         switch statement {
         case .expression(let expr):
             let _ = try evaluate(expr: expr)
-        case .if(let testExpr, let consequentStmt, let alternativeStmt):
+        case .if(_, let testExpr, let consequentStmt, let alternativeStmt):
             try handleIfStatement(testExpr: testExpr,
                                   consequentStmt: consequentStmt,
                                   alternativeStmt: alternativeStmt)

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -74,7 +74,7 @@ class Interpreter {
             try handleBlock(statements: statements)
         case .while(_, let expr, let stmt):
             try handleWhileStatement(expr: expr, stmt: stmt)
-        case .for(let initializerStmt, let testExpr, let incrementExpr, let bodyStmt):
+        case .for(_, let initializerStmt, let testExpr, let incrementExpr, let bodyStmt):
             try handleForStatement(initializerStmt: initializerStmt,
                                    testExpr: testExpr,
                                    incrementExpr: incrementExpr,

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -66,7 +66,7 @@ class Interpreter {
         case .switch(_, let testExpr, let switchCaseDecls):
             try handleSwitchStatement(testExpr: testExpr,
                                       switchCaseDecls: switchCaseDecls)
-        case .print(let expr):
+        case .print(_, let expr):
             try handlePrintStatement(expr: expr)
         case .variableDeclaration(let name, let expr):
             try handleVariableDeclaration(name: name, expr: expr)

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -623,7 +623,7 @@ class Interpreter {
 
             return dictionary[key]
         default:
-            throw RuntimeError.notAListOrDictionary
+            throw RuntimeError.notAListOrDictionary(collectionExpr.locToken)
         }
     }
 
@@ -645,7 +645,7 @@ class Interpreter {
 
             dictionary[key] = value
         default:
-            throw RuntimeError.notAListOrDictionary
+            throw RuntimeError.notAListOrDictionary(collectionExpr.locToken)
         }
 
         return value

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -55,7 +55,7 @@ class Interpreter {
         return nil
     }
 
-    private func execute(statement: Statement<Int>) throws {
+    func execute(statement: Statement<Int>) throws {
         switch statement {
         case .expression(let expr):
             let _ = try evaluate(expr: expr)
@@ -335,8 +335,8 @@ class Interpreter {
                                            valueExpr: valueExpr)
         case .this(let thisToken, let depth):
             return try handleThis(thisToken: thisToken, depth: depth)
-        case .lambda(_, let parameterList, let statements):
-            return try handleLambdaExpression(parameterList: parameterList, statements: statements)
+        case .lambda(_, let parameterList, let body):
+            return try handleLambdaExpression(parameterList: parameterList, body: body)
         case .super(let superToken, let methodToken, let depth):
             return try handleSuperExpression(superToken: superToken, methodToken: methodToken, depth: depth)
         case .string(let stringToken):
@@ -556,13 +556,13 @@ class Interpreter {
         return try environment.getValueAtDepth(nameToken: thisToken, depth: depth)
     }
 
-    private func handleLambdaExpression(parameterList: ParameterList?, statements: [Statement<Int>]) throws -> LoxValue {
+    private func handleLambdaExpression(parameterList: ParameterList?, body: Statement<Int>) throws -> LoxValue {
         let environmentWhenDeclared = self.environment
 
         let function = UserDefinedFunction(name: "lambda",
                                            parameterList: parameterList,
                                            enclosingEnvironment: environmentWhenDeclared,
-                                           body: statements,
+                                           body: body,
                                            isInitializer: false)
 
         return .userDefinedFunction(function)

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -70,7 +70,7 @@ class Interpreter {
             try handlePrintStatement(expr: expr)
         case .variableDeclaration(let name, let expr):
             try handleVariableDeclaration(name: name, expr: expr)
-        case .block(let statements):
+        case .block(_, let statements):
             try handleBlock(statements: statements)
         case .while(let expr, let stmt):
             try handleWhileStatement(expr: expr, stmt: stmt)

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -343,9 +343,9 @@ class Interpreter {
             return try handleStringExpression(stringToken: stringToken)
         case .list(_, let elements):
             return try handleListExpression(elements: elements)
-        case .subscriptGet(let listExpr, let indexExpr):
+        case .subscriptGet(_, let listExpr, let indexExpr):
             return try handleSubscriptGetExpression(collectionExpr: listExpr, indexExpr: indexExpr)
-        case .subscriptSet(let listExpr, let indexExpr, let valueExpr):
+        case .subscriptSet(_, let listExpr, let indexExpr, let valueExpr):
             return try handleSubscriptSetExpression(collectionExpr: listExpr,
                                                     indexExpr: indexExpr,
                                                     valueExpr: valueExpr)

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -207,7 +207,7 @@ class Interpreter {
 
     private func handleFunctionDeclaration(name: Token, lambda: Expression<Int>) throws {
         guard case .lambda(_, let parameterList, let body) = lambda else {
-            throw RuntimeError.notALambda
+            fatalError("Fatal error: expected lambda as body of function declaration")
         }
 
         let environmentWhenDeclared = self.environment
@@ -508,7 +508,7 @@ class Interpreter {
         case .instance(let klass as LoxClass):
             klass
         default:
-            throw RuntimeError.notACallableObject
+            throw RuntimeError.notACallableObject(rightParen)
         }
 
         let argValues = try evaluateAndFlatten(exprs: args)
@@ -662,13 +662,13 @@ class Interpreter {
 
     // Utility functions
     private func makeMethodLookup(methodDecls: [Statement<Int>]) throws -> [String: UserDefinedFunction] {
-        return try methodDecls.reduce(into: [:]) { lookup, methodDecl in
+        return methodDecls.reduce(into: [:]) { lookup, methodDecl in
             guard case .function(let nameToken, let lambdaExpr) = methodDecl else {
-                throw RuntimeError.notAFunctionDeclaration
+                fatalError("Fatal error: expected function declaration in class")
             }
 
             guard case .lambda(_, let parameterList, let methodBody) = lambdaExpr else {
-                throw RuntimeError.notALambda
+                fatalError("Fatal error: expected lambda as body of function declaration")
             }
 
             let isInitializer = nameToken.lexeme == "init"

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -72,7 +72,7 @@ class Interpreter {
             try handleVariableDeclaration(name: name, expr: expr)
         case .block(_, let statements):
             try handleBlock(statements: statements)
-        case .while(let expr, let stmt):
+        case .while(_, let expr, let stmt):
             try handleWhileStatement(expr: expr, stmt: stmt)
         case .for(let initializerStmt, let testExpr, let incrementExpr, let bodyStmt):
             try handleForStatement(initializerStmt: initializerStmt,

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -71,8 +71,7 @@ class Interpreter {
         case .variableDeclaration(let name, let expr):
             try handleVariableDeclaration(name: name, expr: expr)
         case .block(let statements):
-            try handleBlock(statements: statements,
-                            environment: Environment(enclosingEnvironment: environment))
+            try handleBlock(statements: statements)
         case .while(let expr, let stmt):
             try handleWhileStatement(expr: expr, stmt: stmt)
         case .for(let initializerStmt, let testExpr, let incrementExpr, let bodyStmt):
@@ -245,9 +244,9 @@ class Interpreter {
         environment.define(name: name.lexeme, value: value)
     }
 
-    func handleBlock(statements: [Statement<Int>], environment: Environment) throws {
+    func handleBlock(statements: [Statement<Int>]) throws {
         let environmentBeforeBlock = self.environment
-        self.environment = environment
+        self.environment = Environment(enclosingEnvironment: environmentBeforeBlock)
 
         // This ensures that the previous environment is restored
         // if the try below throws, which is what will happen if

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -695,7 +695,7 @@ class Interpreter {
         let values = try exprs.flatMap { expr in
             if case .splat = expr {
                 guard case .instance(let list as LoxList) = try evaluate(expr: expr) else {
-                    throw RuntimeError.notAList
+                    throw RuntimeError.notAList(expr.locToken)
                 }
                 return list.elements
             } else {

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -63,7 +63,7 @@ class Interpreter {
             try handleIfStatement(testExpr: testExpr,
                                   consequentStmt: consequentStmt,
                                   alternativeStmt: alternativeStmt)
-        case .switch(let testExpr, let switchCaseDecls):
+        case .switch(_, let testExpr, let switchCaseDecls):
             try handleSwitchStatement(testExpr: testExpr,
                                       switchCaseDecls: switchCaseDecls)
         case .print(let expr):
@@ -209,7 +209,7 @@ class Interpreter {
     }
 
     private func handleFunctionDeclaration(name: Token, lambda: Expression<Int>) throws {
-        guard case .lambda(let parameterList, let body) = lambda else {
+        guard case .lambda(_, let parameterList, let body) = lambda else {
             throw RuntimeError.notALambda
         }
 
@@ -335,7 +335,7 @@ class Interpreter {
                                            valueExpr: valueExpr)
         case .this(let thisToken, let depth):
             return try handleThis(thisToken: thisToken, depth: depth)
-        case .lambda(let parameterList, let statements):
+        case .lambda(_, let parameterList, let statements):
             return try handleLambdaExpression(parameterList: parameterList, statements: statements)
         case .super(let superToken, let methodToken, let depth):
             return try handleSuperExpression(superToken: superToken, methodToken: methodToken, depth: depth)
@@ -349,7 +349,7 @@ class Interpreter {
             return try handleSubscriptSetExpression(collectionExpr: listExpr,
                                                     indexExpr: indexExpr,
                                                     valueExpr: valueExpr)
-        case .splat(let listExpr):
+        case .splat(_, let listExpr):
             return try handleSplatExpression(listExpr: listExpr)
         case .dictionary(let kvPairs):
             return try handleDictionary(kvExprPairs: kvPairs)
@@ -666,7 +666,7 @@ class Interpreter {
                 throw RuntimeError.notAFunctionDeclaration
             }
 
-            guard case .lambda(let parameterList, let methodBody) = lambdaExpr else {
+            guard case .lambda(_, let parameterList, let methodBody) = lambdaExpr else {
                 throw RuntimeError.notALambda
             }
 

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -310,7 +310,7 @@ class Interpreter {
         switch expr {
         case .literal(_, let literal):
             return literal
-        case .grouping(let expr):
+        case .grouping(_, let expr):
             return try evaluate(expr: expr)
         case .unary(let oper, let expr):
             return try handleUnaryExpression(oper: oper, expr: expr)

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -584,8 +584,8 @@ class Interpreter {
         }
 
         let dummyThisToken = Token(type: .identifier, lexeme: "this", line: 0)
-        guard case .instance(let thisInstance) = try environment.getValueAtDepth(nameToken: dummyThisToken, depth: depth - 1) else {
-            throw RuntimeError.thisNotResolved
+        guard case .instance(let thisInstance)? = try? environment.getValueAtDepth(nameToken: dummyThisToken, depth: depth - 1) else {
+            fatalError("unable to resolve `this` at depth, \(depth - 1)")
         }
 
         if let method = superclass.findMethod(name: methodToken.lexeme) {

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -508,7 +508,7 @@ class Interpreter {
         case .instance(let klass as LoxClass):
             klass
         default:
-            throw RuntimeError.notACallableObject(rightParen)
+            throw RuntimeError.notACallableObject(calleeExpr.locToken)
         }
 
         let argValues = try evaluateAndFlatten(exprs: args)
@@ -539,7 +539,7 @@ class Interpreter {
                                      instanceExpr: Expression<Int>,
                                      propertyNameToken: Token) throws -> LoxValue {
         guard case .instance(let instance) = try evaluate(expr: instanceExpr) else {
-            throw RuntimeError.onlyInstancesHaveProperties(locToken)
+            throw RuntimeError.onlyInstancesHaveProperties(instanceExpr.locToken)
         }
 
         let property = try instance.get(propertyName: propertyNameToken)
@@ -621,7 +621,7 @@ class Interpreter {
                 throw RuntimeError.indexMustBeAnInteger(indexExpr.locToken)
             }
 
-            return list[Int(index)]
+            return list[index]
         case .instance(let dictionary as LoxDictionary):
             let key = try evaluate(expr: indexExpr)
 

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -308,7 +308,7 @@ class Interpreter {
 
     private func evaluate(expr: Expression<Int>) throws -> LoxValue {
         switch expr {
-        case .literal(let literal):
+        case .literal(_, let literal):
             return literal
         case .grouping(let expr):
             return try evaluate(expr: expr)

--- a/slox/Interpreter.swift
+++ b/slox/Interpreter.swift
@@ -184,11 +184,7 @@ class Interpreter {
                                        caseTokens: [Token],
                                        methods: [Statement<Int>],
                                        staticMethods: [Statement<Int>]) throws {
-        let dummyEnumToken = Token(type: .identifier, lexeme: "Enum", line: 0)
-        guard case .instance(let enumSuperclass as LoxClass) = try environment.getValue(nameToken: dummyEnumToken) else {
-            throw RuntimeError.standardLibraryFailedToLoad
-        }
-
+        let enumSuperclass = lookUpStandardLibraryClass(named: "Enum")
         let enumClass = LoxEnum(name: nameToken.lexeme,
                                 superclass: enumSuperclass,
                                 methods: [:])
@@ -658,12 +654,9 @@ class Interpreter {
             kvPairs[key] = value
         }
 
-        let dummyDictionaryToken = Token(type: .identifier, lexeme: "Dictionary", line: 0)
-        guard case .instance(let dictionaryClass as LoxClass) = try environment.getValue(nameToken: dummyDictionaryToken) else {
-            throw RuntimeError.standardLibraryFailedToLoad
-        }
-
+        let dictionaryClass = lookUpStandardLibraryClass(named: "Dictionary")
         let dictionary = LoxDictionary(kvPairs: kvPairs, klass: dictionaryClass)
+
         return .instance(dictionary)
     }
 
@@ -704,33 +697,33 @@ class Interpreter {
         return values
     }
 
-    func makeString(string: String) throws -> LoxValue {
-        let dummyStringToken = Token(type: .identifier, lexeme: "String", line: 0)
-        guard case .instance(let stringClass as LoxClass) = try environment.getValue(nameToken: dummyStringToken) else {
-            throw RuntimeError.standardLibraryFailedToLoad
+    private func lookUpStandardLibraryClass(named name: String) -> LoxClass {
+        let dummyToken = Token(type: .identifier, lexeme: name, line: 0)
+        guard case .instance(let klass as LoxClass)? = try? environment.getValue(nameToken: dummyToken) else {
+            fatalError("no class '\(name)' found in standard library")
         }
 
+        return klass
+    }
+
+    func makeString(string: String) throws -> LoxValue {
+        let stringClass = lookUpStandardLibraryClass(named: "String")
         let list = LoxString(string: string, klass: stringClass)
+
         return .instance(list)
     }
 
     func makeList(elements: [LoxValue]) throws -> LoxValue {
-        let dummyListToken = Token(type: .identifier, lexeme: "List", line: 0)
-        guard case .instance(let listClass as LoxClass) = try environment.getValue(nameToken: dummyListToken) else {
-            throw RuntimeError.standardLibraryFailedToLoad
-        }
-
+        let listClass = lookUpStandardLibraryClass(named: "List")
         let list = LoxList(elements: elements, klass: listClass)
+
         return .instance(list)
     }
 
     func makeDictionary(kvPairs: [LoxValue: LoxValue]) throws -> LoxValue {
-        let dummyDictionaryToken = Token(type: .identifier, lexeme: "Dictionary", line: 0)
-        guard case .instance(let dictionaryClass as LoxClass) = try environment.getValue(nameToken: dummyDictionaryToken) else {
-            throw RuntimeError.standardLibraryFailedToLoad
-        }
-
+        let dictionaryClass = lookUpStandardLibraryClass(named: "Dictionary")
         let dictionary = LoxDictionary(kvPairs: kvPairs, klass: dictionaryClass)
+
         return .instance(dictionary)
     }
 }

--- a/slox/LoxDictionary.swift
+++ b/slox/LoxDictionary.swift
@@ -18,8 +18,8 @@ class LoxDictionary: LoxInstance {
         super.init(klass: klass)
     }
 
-    override func get(propertyName: String) throws -> LoxValue {
-        switch propertyName {
+    override func get(propertyName: Token) throws -> LoxValue {
+        switch propertyName.lexeme {
         case "count":
             return .int(self.kvPairs.count)
         default:
@@ -27,8 +27,8 @@ class LoxDictionary: LoxInstance {
         }
     }
 
-    override func set(propertyName: String, propertyValue: LoxValue) throws {
-        throw RuntimeError.onlyInstancesHaveProperties
+    override func set(propertyName: Token, propertyValue: LoxValue) throws {
+        throw RuntimeError.onlyInstancesHaveProperties(propertyName)
     }
 
     subscript(key: LoxValue) -> LoxValue {

--- a/slox/LoxEnum.swift
+++ b/slox/LoxEnum.swift
@@ -13,7 +13,7 @@ class LoxEnum: LoxClass {
         return ParameterList(normalParameters: parameters)
     }
 
-    override func set(propertyName: String, propertyValue: LoxValue) throws {
-        throw RuntimeError.onlyInstancesHaveProperties
+    override func set(propertyName: Token, propertyValue: LoxValue) throws {
+        throw RuntimeError.onlyInstancesHaveProperties(propertyName)
     }
 }

--- a/slox/LoxInstance.swift
+++ b/slox/LoxInstance.swift
@@ -32,12 +32,12 @@ class LoxInstance {
         self._klass = klass
     }
 
-    func get(propertyName: String) throws -> LoxValue {
-        if let propertyValue = self.properties[propertyName] {
+    func get(propertyName: Token) throws -> LoxValue {
+        if let propertyValue = self.properties[propertyName.lexeme] {
             return propertyValue
         }
 
-        if let method = klass.findMethod(name: propertyName) {
+        if let method = klass.findMethod(name: propertyName.lexeme) {
             let boundMethod = method.bind(instance: self)
             return .userDefinedFunction(boundMethod)
         }
@@ -45,7 +45,7 @@ class LoxInstance {
         throw RuntimeError.undefinedProperty(propertyName)
     }
 
-    func set(propertyName: String, propertyValue: LoxValue) throws {
-        self.properties[propertyName] = propertyValue
+    func set(propertyName: Token, propertyValue: LoxValue) throws {
+        self.properties[propertyName.lexeme] = propertyValue
     }
 }

--- a/slox/LoxList.swift
+++ b/slox/LoxList.swift
@@ -21,8 +21,8 @@ class LoxList: LoxInstance {
         super.init(klass: klass)
     }
 
-    override func get(propertyName: String) throws -> LoxValue {
-        switch propertyName {
+    override func get(propertyName: Token) throws -> LoxValue {
+        switch propertyName.lexeme {
         case "count":
             return .int(elements.count)
         default:
@@ -30,8 +30,8 @@ class LoxList: LoxInstance {
         }
     }
 
-    override func set(propertyName: String, propertyValue: LoxValue) throws {
-        throw RuntimeError.onlyInstancesHaveProperties
+    override func set(propertyName: Token, propertyValue: LoxValue) throws {
+        throw RuntimeError.onlyInstancesHaveProperties(propertyName)
     }
 
     // TODO: Need to think about how to handle invalid indices!!!

--- a/slox/LoxString.swift
+++ b/slox/LoxString.swift
@@ -20,8 +20,8 @@ class LoxString: LoxInstance {
         super.init(klass: klass)
     }
 
-    override func get(propertyName: String) throws -> LoxValue {
-        switch propertyName {
+    override func get(propertyName: Token) throws -> LoxValue {
+        switch propertyName.lexeme {
         case "count":
             return .int(string.count)
         default:
@@ -29,7 +29,7 @@ class LoxString: LoxInstance {
         }
     }
 
-    override func set(propertyName: String, propertyValue: LoxValue) throws {
-        throw RuntimeError.onlyInstancesHaveProperties
+    override func set(propertyName: Token, propertyValue: LoxValue) throws {
+        throw RuntimeError.onlyInstancesHaveProperties(propertyName)
     }
 }

--- a/slox/LoxValue.swift
+++ b/slox/LoxValue.swift
@@ -122,7 +122,7 @@ enum LoxValue: CustomStringConvertible, CustomDebugStringConvertible, Equatable,
         case .double(let number):
             return Int(number)
         default:
-            throw RuntimeError.notANumber
+            fatalError("expected a number")
         }
     }
 
@@ -133,7 +133,7 @@ enum LoxValue: CustomStringConvertible, CustomDebugStringConvertible, Equatable,
         case .double(let number):
             return number
         default:
-            throw RuntimeError.notANumber
+            fatalError("expected a number")
         }
     }
 

--- a/slox/NativeFunction.swift
+++ b/slox/NativeFunction.swift
@@ -99,7 +99,7 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             return .nil
         case .containsNative:
             guard case .instance(let loxList as LoxList) = args[0] else {
-                throw RuntimeError.notAList
+                fatalError("callee is not a list")
             }
 
             let element = args[1]
@@ -107,7 +107,7 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             return .boolean(loxList.elements.contains(element))
         case .appendNative:
             guard case .instance(let loxList as LoxList) = args[0] else {
-                throw RuntimeError.notAList
+                fatalError("callee is not a list")
             }
 
             let element = args[1]
@@ -116,7 +116,7 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             return .nil
         case .deleteAtNative:
             guard case .instance(let loxList as LoxList) = args[0] else {
-                throw RuntimeError.notAList
+                fatalError("callee is not a list")
             }
 
             guard case .int(let index) = args[1] else {

--- a/slox/NativeFunction.swift
+++ b/slox/NativeFunction.swift
@@ -124,9 +124,21 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             }
 
             return loxList.elements.remove(at: Int(index))
+        case .firstIndexNative:
+            guard case .instance(let loxList as LoxList) = args[0] else {
+                fatalError("callee is not a list")
+            }
+
+            let element = args[1]
+
+            if let index = loxList.elements.firstIndex(of: element) {
+                return .int(index)
+            }
+
+            return .nil
         case .removeValueNative:
             guard case .instance(let loxDictionary as LoxDictionary) = args[0] else {
-                throw RuntimeError.notADictionary
+                fatalError("callee is not a dictionary")
             }
 
             let key = args[1]
@@ -134,7 +146,7 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             return loxDictionary.kvPairs.removeValue(forKey: key) ?? .nil
         case .keysNative:
             guard case .instance(let loxDictionary as LoxDictionary) = args[0] else {
-                throw RuntimeError.notADictionary
+                fatalError("callee is not a dictionary")
             }
 
             let keys = Array(loxDictionary.kvPairs.keys)
@@ -142,7 +154,7 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             return try! interpreter.makeList(elements: keys)
         case .valuesNative:
             guard case .instance(let loxDictionary as LoxDictionary) = args[0] else {
-                throw RuntimeError.notADictionary
+                fatalError("callee is not a dictionary")
             }
 
             let values = Array(loxDictionary.kvPairs.values)
@@ -170,7 +182,7 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             return .double(Double.random(in: start...end))
         case .charsNative:
             guard case .instance(let loxString as LoxString) = args[0] else {
-                throw RuntimeError.notAString
+                fatalError("callee is not a string")
             }
 
             let characters = try loxString.string.unicodeScalars.map { unicodeScalar in
@@ -178,21 +190,9 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             }
 
             return try interpreter.makeList(elements: characters)
-        case .firstIndexNative:
-            guard case .instance(let loxList as LoxList) = args[0] else {
-                throw RuntimeError.notAString
-            }
-
-            let element = args[1]
-
-            if let index = loxList.elements.firstIndex(of: element) {
-                return .int(index)
-            }
-
-            return .nil
         case .allCasesNative:
             guard case .instance(let loxEnum as LoxEnum) = args[0] else {
-                fatalError()
+                fatalError("callee is not an enum")
             }
 
             var allCases: [LoxValue] = []

--- a/slox/NativeFunction.swift
+++ b/slox/NativeFunction.swift
@@ -120,7 +120,7 @@ enum NativeFunction: LoxCallable, Equatable, CaseIterable {
             }
 
             guard case .int(let index) = args[1] else {
-                throw RuntimeError.indexMustBeAnInteger
+                throw RuntimeError.indexMustBeAnInteger(nil)
             }
 
             return loxList.elements.remove(at: Int(index))

--- a/slox/ParameterList.swift
+++ b/slox/ParameterList.swift
@@ -9,18 +9,12 @@ struct ParameterList: Equatable {
     var normalParameters: [Token]
     var variadicParameter: Token?
 
-    func checkArity(argCount: Int) throws {
+    func checkArity(argCount: Int) -> Bool {
         let normalParameterCount = normalParameters.count
-        if let variadicParameter {
-            guard argCount >= normalParameterCount else {
-                throw RuntimeError.wrongArity(normalParameterCount, argCount)
-            }
-
-            return
+        if variadicParameter != nil {
+            return argCount >= normalParameterCount
         }
 
-        guard argCount == normalParameterCount else {
-            throw RuntimeError.wrongArity(normalParameterCount, argCount)
-        }
+        return argCount == normalParameterCount
     }
 }

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -514,6 +514,7 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.while]) else {
             return nil
         }
+        let whileToken = previousToken
 
         if !currentTokenMatchesAny(types: [.leftParen]) {
             throw ParseError.missingOpenParenForWhileStatement(currentToken)
@@ -525,7 +526,7 @@ struct Parser {
         }
 
         let stmt = try parseStatement()
-        return .while(expr, stmt)
+        return .while(whileToken, expr, stmt)
     }
 
     mutating private func parseBlock() throws -> Statement<UnresolvedDepth>? {

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -853,20 +853,21 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.leftBracket]) else {
             return nil
         }
+        let leftBracketToken = previousToken
 
         if currentTokenMatchesAny(types: [.rightBracket]) {
-            return .list([])
+            return .list(leftBracketToken, [])
         }
 
         if currentTokenMatchesAny(types: [.colon]) && currentTokenMatchesAny(types: [.rightBracket]) {
-            return .dictionary([])
+            return .dictionary(leftBracketToken, [])
         }
 
         let firstExpr = try parseExpression()
 
         if currentTokenMatchesAny(types: [.colon]) {
             let kvPairs = try parseKeyValuePairs(firstKeyExpr: firstExpr)
-            return .dictionary(kvPairs)
+            return .dictionary(leftBracketToken, kvPairs)
         }
 
         let elements = try parseRemainingExpressions(firstExpr: firstExpr)
@@ -875,7 +876,7 @@ struct Parser {
             throw ParseError.missingClosingBracket(previousToken)
         }
 
-        return .list(elements)
+        return .list(leftBracketToken, elements)
     }
 
     mutating private func parseSuperExpression() throws -> Expression<UnresolvedDepth>? {

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -398,6 +398,7 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.colon]) else {
             throw ParseError.missingColon(currentToken)
         }
+        let colonToken = previousToken
 
         var statements: [Statement<UnresolvedDepth>] = []
         while !currentTokenMatches(type: .case) && !currentTokenMatches(type: .default) && !currentTokenMatches(type: .rightBrace) {
@@ -407,7 +408,7 @@ struct Parser {
 
         return SwitchCaseDeclaration(caseToken: caseToken,
                                      valueExpressions: valueExprs,
-                                     statement: .block(statements))
+                                     statement: .block(colonToken, statements))
     }
 
     mutating private func parseSwitchDefaultDeclaration() throws -> SwitchCaseDeclaration<UnresolvedDepth>? {
@@ -419,6 +420,7 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.colon]) else {
             throw ParseError.missingColon(currentToken)
         }
+        let colonToken = previousToken
 
         var statements: [Statement<UnresolvedDepth>] = []
         while !currentTokenMatches(type: .rightBrace) && currentToken.type != .eof {
@@ -427,7 +429,7 @@ struct Parser {
         }
 
         let switchCaseDecl = SwitchCaseDeclaration(caseToken: defaultToken,
-                                                   statement: .block(statements))
+                                                   statement: .block(colonToken, statements))
         return switchCaseDecl
     }
 
@@ -530,6 +532,7 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.leftBrace]) else {
             return nil
         }
+        let leftBraceToken = previousToken
 
         var statements: [Statement<UnresolvedDepth>] = []
 
@@ -542,7 +545,7 @@ struct Parser {
             throw ParseError.missingClosingBrace(previousToken)
         }
 
-        return .block(statements)
+        return .block(leftBraceToken, statements)
     }
 
     mutating private func parseExpressionStatement() throws -> Statement<UnresolvedDepth> {

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -297,7 +297,7 @@ struct Parser {
             initializerStmt = try parseExpressionStatement()
         }
 
-        var testExpr: Expression<UnresolvedDepth> = .literal(.boolean(true))
+        var testExpr: Expression<UnresolvedDepth> = .literal(Token(type: .true, lexeme: "true", line: 0), .boolean(true))
         if !currentTokenMatches(type: .semicolon) {
             testExpr = try parseExpression()
         }
@@ -787,24 +787,24 @@ struct Parser {
         }
 
         if currentTokenMatchesAny(types: [.false]) {
-            return .literal(.boolean(false))
+            return .literal(previousToken, .boolean(false))
         }
 
         if currentTokenMatchesAny(types: [.true]) {
-            return .literal(.boolean(true))
+            return .literal(previousToken, .boolean(true))
         }
 
         if currentTokenMatchesAny(types: [.nil]) {
-            return .literal(.nil)
+            return .literal(previousToken, .nil)
         }
 
         if currentTokenMatchesAny(types: [.double]) {
             let number = Double(previousToken.lexeme)!
-            return .literal(.double(number))
+            return .literal(previousToken, .double(number))
         }
         if currentTokenMatchesAny(types: [.int]) {
             let number = Int(previousToken.lexeme)!
-            return .literal(.int(number))
+            return .literal(previousToken, .int(number))
         }
 
         if currentTokenMatchesAny(types: [.string]) {
@@ -881,8 +881,8 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.super]) else {
             return nil
         }
-
         let superToken = previousToken
+
         if !currentTokenMatchesAny(types: [.dot]) {
             throw ParseError.missingDotAfterSuper(currentToken)
         }

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -618,8 +618,8 @@ struct Parser {
 
         if case .variable(let name, let depth) = expr {
             return .assignment(name, newValueExpr, depth)
-        } else if case .get(let instanceExpr, let propertyNameToken) = expr {
-            return .set(instanceExpr, propertyNameToken, newValueExpr)
+        } else if case .get(let locToken, let instanceExpr, let propertyNameToken) = expr {
+            return .set(locToken, instanceExpr, propertyNameToken, newValueExpr)
         } else if case .subscriptGet(let listExpr, let indexExpr) = expr {
             return .subscriptSet(listExpr, indexExpr, newValueExpr)
         }
@@ -758,12 +758,13 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.dot]) else {
             return nil
         }
+        let locToken = previousToken
 
         guard currentTokenMatchesAny(types: [.identifier]) else {
             throw ParseError.missingIdentifierAfterDot(currentToken)
         }
 
-        return .get(expr, previousToken)
+        return .get(locToken, expr, previousToken)
     }
 
     mutating private func parseSubscript(expr: Expression<UnresolvedDepth>) throws -> Expression<UnresolvedDepth>? {

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -838,6 +838,7 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.leftParen]) else {
             return nil
         }
+        let leftParenToken = previousToken
 
         let expr = try parseExpression()
 
@@ -845,7 +846,7 @@ struct Parser {
             throw ParseError.missingClosingParenthesis(currentToken)
         }
 
-        return .grouping(expr)
+        return .grouping(leftParenToken, expr)
     }
 
     mutating private func parseCollectionExpression() throws -> Expression<UnresolvedDepth>? {

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -272,8 +272,8 @@ struct Parser {
             return whileStmt
         }
 
-        if let blockStmts = try parseBlock() {
-            return .block(blockStmts)
+        if let blockStmt = try parseBlock() {
+            return blockStmt
         }
 
         return try parseExpressionStatement()
@@ -526,7 +526,7 @@ struct Parser {
         return .while(expr, stmt)
     }
 
-    mutating private func parseBlock() throws -> [Statement<UnresolvedDepth>]? {
+    mutating private func parseBlock() throws -> Statement<UnresolvedDepth>? {
         guard currentTokenMatchesAny(types: [.leftBrace]) else {
             return nil
         }
@@ -542,7 +542,7 @@ struct Parser {
             throw ParseError.missingClosingBrace(previousToken)
         }
 
-        return statements
+        return .block(statements)
     }
 
     mutating private func parseExpressionStatement() throws -> Statement<UnresolvedDepth> {

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -283,6 +283,7 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.for]) else {
             return nil
         }
+        let forToken = previousToken
 
         if !currentTokenMatchesAny(types: [.leftParen]) {
             throw ParseError.missingOpenParenForForStatement(currentToken)
@@ -315,7 +316,7 @@ struct Parser {
 
         let bodyStmt = try parseStatement()
 
-        return .for(initializerStmt, testExpr, incrementExpr, bodyStmt)
+        return .for(forToken, initializerStmt, testExpr, incrementExpr, bodyStmt)
     }
 
     mutating private func parseIfStatement() throws -> Statement<UnresolvedDepth>? {

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -322,6 +322,7 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.if]) else {
             return nil
         }
+        let ifToken = previousToken
 
         if !currentTokenMatchesAny(types: [.leftParen]) {
             throw ParseError.missingOpenParenForIfStatement(currentToken)
@@ -339,7 +340,7 @@ struct Parser {
             alternativeStmt = try parseStatement()
         }
 
-        return .if(testExpr, consequentStmt, alternativeStmt)
+        return .if(ifToken, testExpr, consequentStmt, alternativeStmt)
     }
 
     mutating private func parseSwitchStatement() throws -> Statement<UnresolvedDepth>? {
@@ -464,7 +465,6 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.return]) else {
             return nil
         }
-
         let returnToken = previousToken
 
         var expr: Expression<UnresolvedDepth>? = nil

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -620,8 +620,8 @@ struct Parser {
             return .assignment(name, newValueExpr, depth)
         } else if case .get(let locToken, let instanceExpr, let propertyNameToken) = expr {
             return .set(locToken, instanceExpr, propertyNameToken, newValueExpr)
-        } else if case .subscriptGet(let listExpr, let indexExpr) = expr {
-            return .subscriptSet(listExpr, indexExpr, newValueExpr)
+        } else if case .subscriptGet(let leftBracketToken, let listExpr, let indexExpr) = expr {
+            return .subscriptSet(leftBracketToken, listExpr, indexExpr, newValueExpr)
         }
 
         throw ParseError.invalidAssignmentTarget(assignmentOperToken)
@@ -771,6 +771,7 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.leftBracket]) else {
             return nil
         }
+        let leftBracketToken = previousToken
 
         let indexExpr = try parseLogicOr()
 
@@ -778,7 +779,7 @@ struct Parser {
             throw ParseError.missingCloseBracketForSubscriptAccess(currentToken)
         }
 
-        return .subscriptGet(expr, indexExpr)
+        return .subscriptGet(leftBracketToken, expr, indexExpr)
     }
 
     mutating private func parsePrimary() throws -> Expression<UnresolvedDepth> {

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -435,6 +435,7 @@ struct Parser {
         guard currentTokenMatchesAny(types: [.print]) else {
             return nil
         }
+        let printToken = previousToken
 
         let expr = try parseExpression()
 
@@ -442,7 +443,7 @@ struct Parser {
             throw ParseError.missingSemicolon(currentToken)
         }
 
-        return .print(expr)
+        return .print(printToken, expr)
     }
 
     mutating private func parseJumpStatement() throws -> Statement<UnresolvedDepth>? {

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -441,9 +441,9 @@ struct Resolver {
             return try handleThis(thisToken: thisToken)
         case .literal(let valueToken, let value):
             return .literal(valueToken, value)
-        case .grouping(let expr):
+        case .grouping(let leftParenToken, let expr):
             let resolvedExpr = try resolve(expression: expr)
-            return .grouping(resolvedExpr)
+            return .grouping(leftParenToken, resolvedExpr)
         case .logical(let leftExpr, let operToken, let rightExpr):
             return try handleLogical(leftExpr: leftExpr, operToken: operToken, rightExpr: rightExpr)
         case .lambda(let locToken, let parameterList, let statements):

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -428,10 +428,13 @@ struct Resolver {
             return try handleUnary(operToken: operToken, rightExpr: rightExpr)
         case .call(let calleeExpr, let rightParenToken, let args):
             return try handleCall(calleeExpr: calleeExpr, rightParenToken: rightParenToken, args: args)
-        case .get(let instanceExpr, let propertyNameToken):
-            return try handleGet(instanceExpr: instanceExpr, propertyNameToken: propertyNameToken)
-        case .set(let instanceExpr, let propertyNameToken, let valueExpr):
-            return try handleSet(instanceExpr: instanceExpr,
+        case .get(let locToken, let instanceExpr, let propertyNameToken):
+            return try handleGet(locToken: locToken,
+                                 instanceExpr: instanceExpr,
+                                 propertyNameToken: propertyNameToken)
+        case .set(let locToken, let instanceExpr, let propertyNameToken, let valueExpr):
+            return try handleSet(locToken: locToken,
+                                 instanceExpr: instanceExpr,
                                  propertyNameToken: propertyNameToken,
                                  valueExpr: valueExpr)
         case .this(let thisToken, _):
@@ -515,16 +518,18 @@ struct Resolver {
         return .call(resolvedCalleeExpr, rightParenToken, resolvedArgs)
     }
 
-    mutating private func handleGet(instanceExpr: Expression<UnresolvedDepth>,
+    mutating private func handleGet(locToken: Token,
+                                    instanceExpr: Expression<UnresolvedDepth>,
                                     propertyNameToken: Token) throws -> Expression<Int> {
         // Note that we don't attempt to resolve property names
         // because they are defined and looked up at _runtime_.
         let resolvedInstanceExpr = try resolve(expression: instanceExpr)
 
-        return .get(resolvedInstanceExpr, propertyNameToken)
+        return .get(locToken, resolvedInstanceExpr, propertyNameToken)
     }
 
-    mutating private func handleSet(instanceExpr: Expression<UnresolvedDepth>,
+    mutating private func handleSet(locToken: Token,
+                                    instanceExpr: Expression<UnresolvedDepth>,
                                     propertyNameToken: Token,
                                     valueExpr: Expression<UnresolvedDepth>) throws -> Expression<Int> {
         // As with `get` expressions, we do _not_ try to
@@ -532,7 +537,7 @@ struct Resolver {
         let resolvedInstanceExpr = try resolve(expression: instanceExpr)
         let resolvedValueExpr = try resolve(expression: valueExpr)
 
-        return .set(resolvedInstanceExpr, propertyNameToken, resolvedValueExpr)
+        return .set(locToken, resolvedInstanceExpr, propertyNameToken, resolvedValueExpr)
     }
 
     mutating private func handleThis(thisToken: Token) throws -> Expression<Int> {

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -173,7 +173,7 @@ struct Resolver {
 
         let resolvedMethods = try methods.map { method in
             guard case .function(let nameToken, let lambdaExpr) = method else {
-                throw ResolverError.notAFunction
+                fatalError("expected lambda as body of function declaration")
             }
 
             let functionType: FunctionType = if nameToken.lexeme == "init" {
@@ -188,7 +188,7 @@ struct Resolver {
 
         let resolvedStaticMethods = try staticMethods.map { method in
             guard case .function(let nameToken, let lambdaExpr) = method else {
-                throw ResolverError.notAFunction
+                fatalError("expected lambda as body of function declaration")
             }
 
             if nameToken.lexeme == "init" {
@@ -232,7 +232,7 @@ struct Resolver {
 
         let resolvedMethods = try methods.map { method in
             guard case .function(let nameToken, let lambdaExpr) = method else {
-                throw ResolverError.notAFunction
+                fatalError("expected lambda as body of function declaration")
             }
 
             return try handleFunctionDeclaration(nameToken: nameToken,
@@ -242,7 +242,7 @@ struct Resolver {
 
         let resolvedStaticMethods = try staticMethods.map { method in
             guard case .function(let nameToken, let lambdaExpr) = method else {
-                throw ResolverError.notAFunction
+                fatalError("expected lambda as body of function declaration")
             }
 
             if nameToken.lexeme == "init" {
@@ -262,7 +262,7 @@ struct Resolver {
                                                     lambdaExpr: Expression<UnresolvedDepth>,
                                                     functionType: FunctionType) throws -> Statement<Int> {
         guard case .lambda(let locToken, let parameterList, let body) = lambdaExpr else {
-            throw ResolverError.notAFunction
+            fatalError("expected lambda as body of function declaration")
         }
 
         try declareVariable(variableToken: nameToken)

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -50,8 +50,8 @@ struct Resolver {
     // Resolver for statements
     private mutating func resolve(statement: Statement<UnresolvedDepth>) throws -> Statement<Int> {
         switch statement {
-        case .block(let statements):
-            return try handleBlock(statements: statements)
+        case .block(let beginBlockToken, let statements):
+            return try handleBlock(beginBlockToken: beginBlockToken, statements: statements)
         case .variableDeclaration(let nameToken, let initializeExpr):
             return try handleVariableDeclaration(nameToken: nameToken, initializeExpr: initializeExpr)
         case .class(let nameToken, let superclassExpr, let methods, let staticMethods):
@@ -97,7 +97,8 @@ struct Resolver {
         }
     }
 
-    mutating private func handleBlock(statements: [Statement<UnresolvedDepth>]) throws -> Statement<Int> {
+    mutating private func handleBlock(beginBlockToken: Token,
+                                      statements: [Statement<UnresolvedDepth>]) throws -> Statement<Int> {
         beginScope()
         defer {
             endScope()
@@ -105,7 +106,7 @@ struct Resolver {
 
         let resolvedStatements = try resolve(statements: statements)
 
-        return .block(resolvedStatements)
+        return .block(beginBlockToken, resolvedStatements)
     }
 
     mutating private func handleVariableDeclaration(nameToken: Token,
@@ -318,7 +319,7 @@ struct Resolver {
             try resolve(expression: valueExpr)
         }
 
-        guard case .block(let statements) = switchCaseDecl.statement,
+        guard case .block(_, let statements) = switchCaseDecl.statement,
               statements.count > 0 else {
             throw ResolverError.switchMustHaveAtLeastOneStatementPerCaseOrDefault(switchCaseDecl.caseToken)
         }

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -439,8 +439,8 @@ struct Resolver {
                                  valueExpr: valueExpr)
         case .this(let thisToken, _):
             return try handleThis(thisToken: thisToken)
-        case .literal(let value):
-            return .literal(value)
+        case .literal(let valueToken, let value):
+            return .literal(valueToken, value)
         case .grouping(let expr):
             let resolvedExpr = try resolve(expression: expr)
             return .grouping(resolvedExpr)

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -457,10 +457,15 @@ struct Resolver {
             return .string(stringToken)
         case .list(let leftBracketToken, let elements):
             return try handleList(leftBracketToken: leftBracketToken, elements: elements)
-        case .subscriptGet(let listExpr, let indexExpr):
-            return try handleSubscriptGet(listExpr: listExpr, indexExpr: indexExpr)
-        case .subscriptSet(let listExpr, let indexExpr, let valueExpr):
-            return try handleSubscriptSet(listExpr: listExpr, indexExpr: indexExpr, valueExpr: valueExpr)
+        case .subscriptGet(let leftBracketToken, let listExpr, let indexExpr):
+            return try handleSubscriptGet(leftBracketToken: leftBracketToken,
+                                          listExpr: listExpr,
+                                          indexExpr: indexExpr)
+        case .subscriptSet(let leftBracketToken, let listExpr, let indexExpr, let valueExpr):
+            return try handleSubscriptSet(leftBracketToken: leftBracketToken,
+                                          listExpr: listExpr,
+                                          indexExpr: indexExpr,
+                                          valueExpr: valueExpr)
         case .splat(let starToken, let listExpr):
             return try handleSplat(starToken: starToken, listExpr: listExpr)
         case .dictionary(let leftBracketToken, let kvPairs):
@@ -623,22 +628,24 @@ struct Resolver {
         return .list(leftBracketToken, resolvedElements)
     }
 
-    mutating private func handleSubscriptGet(listExpr: Expression<UnresolvedDepth>,
+    mutating private func handleSubscriptGet(leftBracketToken: Token,
+                                             listExpr: Expression<UnresolvedDepth>,
                                              indexExpr: Expression<UnresolvedDepth>) throws -> Expression<Int> {
         let resolvedListExpr = try resolve(expression: listExpr)
         let resolvedIndexExpr = try resolve(expression: indexExpr)
 
-        return .subscriptGet(resolvedListExpr, resolvedIndexExpr)
+        return .subscriptGet(leftBracketToken, resolvedListExpr, resolvedIndexExpr)
     }
 
-    mutating private func handleSubscriptSet(listExpr: Expression<UnresolvedDepth>,
+    mutating private func handleSubscriptSet(leftBracketToken: Token,
+                                             listExpr: Expression<UnresolvedDepth>,
                                              indexExpr: Expression<UnresolvedDepth>,
                                              valueExpr: Expression<UnresolvedDepth>) throws -> Expression<Int> {
         let resolvedListExpr = try resolve(expression: listExpr)
         let resolvedIndexExpr = try resolve(expression: indexExpr)
         let resolvedValueExpr = try resolve(expression: valueExpr)
 
-        return .subscriptSet(resolvedListExpr, resolvedIndexExpr, resolvedValueExpr)
+        return .subscriptSet(leftBracketToken, resolvedListExpr, resolvedIndexExpr, resolvedValueExpr)
     }
 
     mutating private func handleSplat(starToken: Token,

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -455,16 +455,16 @@ struct Resolver {
             return try handleSuper(superToken: superToken, methodToken: methodToken)
         case .string(let stringToken):
             return .string(stringToken)
-        case .list(let elements):
-            return try handleList(elements: elements)
+        case .list(let leftBracketToken, let elements):
+            return try handleList(leftBracketToken: leftBracketToken, elements: elements)
         case .subscriptGet(let listExpr, let indexExpr):
             return try handleSubscriptGet(listExpr: listExpr, indexExpr: indexExpr)
         case .subscriptSet(let listExpr, let indexExpr, let valueExpr):
             return try handleSubscriptSet(listExpr: listExpr, indexExpr: indexExpr, valueExpr: valueExpr)
         case .splat(let starToken, let listExpr):
             return try handleSplat(starToken: starToken, listExpr: listExpr)
-        case .dictionary(let kvPairs):
-            return try handleDictionary(kvPairs: kvPairs)
+        case .dictionary(let leftBracketToken, let kvPairs):
+            return try handleDictionary(leftBracketToken: leftBracketToken, kvPairs: kvPairs)
         }
     }
 
@@ -608,7 +608,8 @@ struct Resolver {
         return .super(superToken, methodToken, depth)
     }
 
-    mutating private func handleList(elements: [Expression<UnresolvedDepth>]) throws -> Expression<Int> {
+    mutating private func handleList(leftBracketToken: Token,
+                                     elements: [Expression<UnresolvedDepth>]) throws -> Expression<Int> {
         let previousArgumentListType = currentArgumentListType
         currentArgumentListType = .listInitializer
         defer {
@@ -619,7 +620,7 @@ struct Resolver {
             return try resolve(expression: element)
         }
 
-        return .list(resolvedElements)
+        return .list(leftBracketToken, resolvedElements)
     }
 
     mutating private func handleSubscriptGet(listExpr: Expression<UnresolvedDepth>,
@@ -651,7 +652,8 @@ struct Resolver {
         return .splat(starToken, resolvedListExpr)
     }
 
-    mutating private func handleDictionary(kvPairs: [(Expression<UnresolvedDepth>, Expression<UnresolvedDepth>)]) throws -> Expression<Int> {
+    mutating private func handleDictionary(leftBracketToken: Token,
+                                           kvPairs: [(Expression<UnresolvedDepth>, Expression<UnresolvedDepth>)]) throws -> Expression<Int> {
         var resolvedKVPairs: [(Expression<Int>, Expression<Int>)] = []
 
         for (keyExpr, valueExpr) in kvPairs {
@@ -660,7 +662,7 @@ struct Resolver {
             resolvedKVPairs.append((resolvedKey, resolvedValue))
         }
 
-        return .dictionary(resolvedKVPairs)
+        return .dictionary(leftBracketToken, resolvedKVPairs)
     }
 
 

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -83,8 +83,10 @@ struct Resolver {
             return try handlePrintStatement(printToken: printToken, expr: expr)
         case .return(let returnToken, let expr):
             return try handleReturnStatement(returnToken: returnToken, expr: expr)
-        case .while(let conditionExpr, let bodyStmt):
-            return try handleWhile(conditionExpr: conditionExpr, bodyStmt: bodyStmt)
+        case .while(let whileToken, let conditionExpr, let bodyStmt):
+            return try handleWhile(whileToken: whileToken,
+                                   conditionExpr: conditionExpr,
+                                   bodyStmt: bodyStmt)
         case .for(let initializerStmt, let testExpr, let incrementExpr, let bodyStmt):
             return try handleFor(initializerStmt: initializerStmt,
                                  testExpr: testExpr,
@@ -372,7 +374,8 @@ struct Resolver {
         return .continue(continueToken)
     }
 
-    mutating private func handleWhile(conditionExpr: Expression<UnresolvedDepth>,
+    mutating private func handleWhile(whileToken: Token,
+                                      conditionExpr: Expression<UnresolvedDepth>,
                                       bodyStmt: Statement<UnresolvedDepth>) throws -> Statement<Int> {
         let previousLoopType = currentJumpableType
         currentJumpableType = .loop
@@ -383,7 +386,7 @@ struct Resolver {
         let resolvedConditionExpr = try resolve(expression: conditionExpr)
         let resolvedBodyStmt = try resolve(statement: bodyStmt)
 
-        return .while(resolvedConditionExpr, resolvedBodyStmt)
+        return .while(whileToken, resolvedConditionExpr, resolvedBodyStmt)
     }
 
     mutating private func handleFor(initializerStmt: Statement<UnresolvedDepth>?,

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -70,8 +70,11 @@ struct Resolver {
                                                  functionType: .function)
         case .expression(let expr):
             return try handleExpressionStatement(expr: expr)
-        case .if(let testExpr, let consequentStmt, let alternativeStmt):
-            return try handleIf(testExpr: testExpr, consequentStmt: consequentStmt, alternativeStmt: alternativeStmt)
+        case .if(let ifToken, let testExpr, let consequentStmt, let alternativeStmt):
+            return try handleIf(ifToken: ifToken,
+                                testExpr: testExpr,
+                                consequentStmt: consequentStmt,
+                                alternativeStmt: alternativeStmt)
         case .switch(let switchToken, let testExpr, let switchCaseDecls):
             return try handleSwitch(switchToken: switchToken,
                                     testExpr: testExpr,
@@ -274,7 +277,8 @@ struct Resolver {
         return .expression(resolvedExpression)
     }
 
-    mutating private func handleIf(testExpr: Expression<UnresolvedDepth>,
+    mutating private func handleIf(ifToken: Token,
+                                   testExpr: Expression<UnresolvedDepth>,
                                    consequentStmt: Statement<UnresolvedDepth>,
                                    alternativeStmt: Statement<UnresolvedDepth>?) throws -> Statement<Int> {
         let resolvedTestExpr = try resolve(expression: testExpr)
@@ -285,7 +289,7 @@ struct Resolver {
             resolvedAlternativeStmt = try resolve(statement: alternativeStmt)
         }
 
-        return .if(resolvedTestExpr, resolvedConsequentStmt, resolvedAlternativeStmt)
+        return .if(ifToken, resolvedTestExpr, resolvedConsequentStmt, resolvedAlternativeStmt)
     }
 
     mutating private func handleSwitch(switchToken: Token,

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -79,8 +79,8 @@ struct Resolver {
             return try handleSwitch(switchToken: switchToken,
                                     testExpr: testExpr,
                                     switchCaseDecls: switchCaseDecls)
-        case .print(let expr):
-            return try handlePrintStatement(expr: expr)
+        case .print(let printToken, let expr):
+            return try handlePrintStatement(printToken: printToken, expr: expr)
         case .return(let returnToken, let expr):
             return try handleReturnStatement(returnToken: returnToken, expr: expr)
         case .while(let conditionExpr, let bodyStmt):
@@ -330,9 +330,10 @@ struct Resolver {
                                      statement: resolvedStmt)
     }
 
-    mutating private func handlePrintStatement(expr: Expression<UnresolvedDepth>) throws -> Statement<Int> {
+    mutating private func handlePrintStatement(printToken: Token,
+                                               expr: Expression<UnresolvedDepth>) throws -> Statement<Int> {
         let resolvedExpression = try resolve(expression: expr)
-        return .print(resolvedExpression)
+        return .print(printToken, resolvedExpression)
     }
 
     mutating private func handleReturnStatement(returnToken: Token, expr: Expression<UnresolvedDepth>?) throws -> Statement<Int> {

--- a/slox/Resolver.swift
+++ b/slox/Resolver.swift
@@ -87,8 +87,9 @@ struct Resolver {
             return try handleWhile(whileToken: whileToken,
                                    conditionExpr: conditionExpr,
                                    bodyStmt: bodyStmt)
-        case .for(let initializerStmt, let testExpr, let incrementExpr, let bodyStmt):
-            return try handleFor(initializerStmt: initializerStmt,
+        case .for(let forToken, let initializerStmt, let testExpr, let incrementExpr, let bodyStmt):
+            return try handleFor(forToken: forToken,
+                                 initializerStmt: initializerStmt,
                                  testExpr: testExpr,
                                  incrementExpr: incrementExpr,
                                  bodyStmt: bodyStmt)
@@ -389,7 +390,8 @@ struct Resolver {
         return .while(whileToken, resolvedConditionExpr, resolvedBodyStmt)
     }
 
-    mutating private func handleFor(initializerStmt: Statement<UnresolvedDepth>?,
+    mutating private func handleFor(forToken: Token,
+                                    initializerStmt: Statement<UnresolvedDepth>?,
                                     testExpr: Expression<UnresolvedDepth>,
                                     incrementExpr: Expression<UnresolvedDepth>?,
                                     bodyStmt: Statement<UnresolvedDepth>) throws -> Statement<Int> {
@@ -418,7 +420,8 @@ struct Resolver {
 
         let resolvedBodyStmt = try resolve(statement: bodyStmt)
 
-        return .for(resolvedInitializerStmt,
+        return .for(forToken,
+                    resolvedInitializerStmt,
                     resolvedTestExpr,
                     resolvedIncrementExpr,
                     resolvedBodyStmt)

--- a/slox/ResolverError.swift
+++ b/slox/ResolverError.swift
@@ -9,7 +9,6 @@ import Foundation
 
 enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
     case variableAccessedBeforeInitialization(Token)
-    case notAFunction
     case variableAlreadyDefined(Token)
     case cannotReturnOutsideFunction(Token)
     case cannotReferenceThisOutsideClass(Token)
@@ -30,8 +29,6 @@ enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
         switch self {
         case .variableAccessedBeforeInitialization(let token):
             return "[Line \(token.line)] Error: cannot read local variable in its own initializer"
-        case .notAFunction:
-            return "Expected lambda as body of function declaration"
         case .variableAlreadyDefined(let token):
             return "[Line \(token.line)] Error: variable \(token.lexeme) already defined in this scope"
         case .cannotReturnOutsideFunction(let token):

--- a/slox/ResolverError.swift
+++ b/slox/ResolverError.swift
@@ -8,60 +8,60 @@
 import Foundation
 
 enum ResolverError: CustomStringConvertible, Equatable, LocalizedError {
-    case variableAccessedBeforeInitialization
+    case variableAccessedBeforeInitialization(Token)
     case notAFunction
-    case variableAlreadyDefined(String)
-    case cannotReturnOutsideFunction
-    case cannotReferenceThisOutsideClass
-    case cannotReturnValueFromInitializer
-    case staticInitsNotAllowed
-    case classCannotInheritFromItself
-    case cannotReferenceSuperOutsideClass
-    case cannotReferenceSuperWithoutSubclassing
-    case cannotBreakOutsideLoopOrSwitch
-    case cannotContinueOutsideLoop
-    case functionsMustHaveAParameterList
-    case cannotUseSplatOperatorOutOfContext
+    case variableAlreadyDefined(Token)
+    case cannotReturnOutsideFunction(Token)
+    case cannotReferenceThisOutsideClass(Token)
+    case cannotReturnValueFromInitializer(Token)
+    case staticInitsNotAllowed(Token)
+    case classCannotInheritFromItself(Token)
+    case cannotReferenceSuperOutsideClass(Token)
+    case cannotReferenceSuperWithoutSubclassing(Token)
+    case cannotBreakOutsideLoopOrSwitch(Token)
+    case cannotContinueOutsideLoop(Token)
+    case functionsMustHaveAParameterList(Token)
+    case cannotUseSplatOperatorOutOfContext(Token)
     case duplicateCaseNamesNotAllowed(Token)
-    case switchMustHaveAtLeastOneCaseOrDefault
-    case switchMustHaveAtLeastOneStatementPerCaseOrDefault
+    case switchMustHaveAtLeastOneCaseOrDefault(Token)
+    case switchMustHaveAtLeastOneStatementPerCaseOrDefault(Token)
 
     var description: String {
         switch self {
-        case .variableAccessedBeforeInitialization:
-            return "Can't read local variable in its own initializer"
+        case .variableAccessedBeforeInitialization(let token):
+            return "[Line \(token.line)] Error: cannot read local variable in its own initializer"
         case .notAFunction:
             return "Expected lambda as body of function declaration"
-        case .variableAlreadyDefined(let name):
-            return "Variable \(name) already defined in this scope"
-        case .cannotReturnOutsideFunction:
-            return "Cannot return from outside a function"
-        case .cannotReferenceThisOutsideClass:
-            return "Cannot use `this` from outside a class"
-        case .cannotReturnValueFromInitializer:
-            return "Cannot return value from an initializer"
-        case .staticInitsNotAllowed:
-            return "Cannot have class-level init function"
-        case .classCannotInheritFromItself:
-            return "Class cannot inherit from itself"
-        case .cannotReferenceSuperOutsideClass:
-            return "Cannot use `super` from outside a class"
-        case .cannotReferenceSuperWithoutSubclassing:
-            return "Cannot use `super` without subclassing"
-        case .cannotBreakOutsideLoopOrSwitch:
-            return "Can only `break` from inside a loop or switch statement"
-        case .cannotContinueOutsideLoop:
-            return "Can only `continue` from inside a `while` or `for` loop"
-        case .functionsMustHaveAParameterList:
-            return "Functions must have a parameter list"
-        case .cannotUseSplatOperatorOutOfContext:
-            return "Cannot use splat operator in this context"
+        case .variableAlreadyDefined(let token):
+            return "[Line \(token.line)] Error: variable \(token.lexeme) already defined in this scope"
+        case .cannotReturnOutsideFunction(let token):
+            return "[Line \(token.line)] Error: cannot return from outside a function"
+        case .cannotReferenceThisOutsideClass(let token):
+            return "[Line \(token.line)] Error: cannot use `this` from outside a class"
+        case .cannotReturnValueFromInitializer(let token):
+            return "[Line \(token.line)] Error: cannot return value from an initializer"
+        case .staticInitsNotAllowed(let token):
+            return "[Line \(token.line)] Error: cannot have class-level init function"
+        case .classCannotInheritFromItself(let token):
+            return "[Line \(token.line)] Error: class cannot inherit from itself"
+        case .cannotReferenceSuperOutsideClass(let token):
+            return "[Line \(token.line)] Error: cannot use `super` from outside a class"
+        case .cannotReferenceSuperWithoutSubclassing(let token):
+            return "[Line \(token.line)] Error: cannot use `super` without subclassing"
+        case .cannotBreakOutsideLoopOrSwitch(let token):
+            return "[Line \(token.line)] Error: can only `break` from inside a loop or switch statement"
+        case .cannotContinueOutsideLoop(let token):
+            return "[Line \(token.line)] Error: can only `continue` from inside a `while` or `for` loop"
+        case .functionsMustHaveAParameterList(let token):
+            return "[Line \(token.line)] Error: functions must have a parameter list"
+        case .cannotUseSplatOperatorOutOfContext(let token):
+            return "[Line \(token.line)] Error: cannot use splat operator in this context"
         case .duplicateCaseNamesNotAllowed(let token):
-            return "Cannot use duplicate case names in enum: \(token.lexeme)"
-        case .switchMustHaveAtLeastOneCaseOrDefault:
-            return "`switch` statement must have at least one `case` or `default` block"
-        case .switchMustHaveAtLeastOneStatementPerCaseOrDefault:
-            return "`Each `case` or `default` block must have at least one statement"
+            return "[Line \(token.line)] Error: cannot use duplicate case names in enum: \(token.lexeme)"
+        case .switchMustHaveAtLeastOneCaseOrDefault(let token):
+            return "[Line \(token.line)] Error: `switch` statement must have at least one `case` or `default` block"
+        case .switchMustHaveAtLeastOneStatementPerCaseOrDefault(let token):
+            return "[Line \(token.line)] Error: `Each `case` or `default` block must have at least one statement"
         }
     }
 }

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -18,7 +18,7 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case notAnInstance
     case notAList
     case notADictionary
-    case notAListOrDictionary
+    case notAListOrDictionary(Token)
     case notANumber
     case notAString
     case notAnInt
@@ -54,8 +54,8 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "Error: expected a list"
         case .notADictionary:
             return "Error: expected a dictionary"
-        case .notAListOrDictionary:
-            return "Error: expected a list or dictionary"
+        case .notAListOrDictionary(let locToken):
+            return "[Line \(locToken.line)] Error: expected a list or dictionary"
         case .notANumber:
             return "Error: expected a number"
         case .notAString:

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
-    case unaryOperandMustBeNumber
-    case unsupportedUnaryOperator
-    case binaryOperandsMustBeNumbers
-    case binaryOperandsMustBeNumbersOrStringsOrLists
-    case unsupportedBinaryOperator
-    case undefinedVariable(String)
+    case unaryOperandMustBeNumber(Token)
+    case unsupportedUnaryOperator(Token)
+    case binaryOperandsMustBeNumbers(Token)
+    case binaryOperandsMustBeNumbersOrStringsOrLists(Token)
+    case unsupportedBinaryOperator(Token)
+    case undefinedVariable(Token)
     case notAFunctionDeclaration
     case notACallableObject
     case notAnInstance
@@ -31,21 +31,23 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case couldNotFindAncestorEnvironmentAtDepth(Int)
     case superclassMustBeAClass
     case indexMustBeAnInteger
+    case thisNotResolved
+    case standardLibraryFailedToLoad
 
     var description: String {
         switch self {
-        case .unaryOperandMustBeNumber:
-            return "Error: operand must be a number"
-        case .unsupportedUnaryOperator:
-            return "Error: unsupported unary operator"
-        case .binaryOperandsMustBeNumbers:
-            return "Error: operands must be both numbers"
-        case .binaryOperandsMustBeNumbersOrStringsOrLists:
-            return "Error: operands must be either both numbers, strings, or lists"
-        case .unsupportedBinaryOperator:
-            return "Error: unsupported binary operator"
-        case .undefinedVariable(let name):
-            return "Error: undefined variable '\(name)'"
+        case .unaryOperandMustBeNumber(let locToken):
+            return "[Line \(locToken.line)] Error: operand must be a number"
+        case .unsupportedUnaryOperator(let locToken):
+            return "[Line \(locToken.line)] Error: unsupported unary operator"
+        case .binaryOperandsMustBeNumbers(let locToken):
+            return "[Line \(locToken.line)] Error: operands must be both numbers"
+        case .binaryOperandsMustBeNumbersOrStringsOrLists(let locToken):
+            return "[Line \(locToken.line)] Error: operands must be either both numbers, strings, or lists"
+        case .unsupportedBinaryOperator(let locToken):
+            return "[Line \(locToken.line)] Error: unsupported binary operator"
+        case .undefinedVariable(let nameToken):
+            return "[Line \(nameToken.line)] Error: undefined variable '\(nameToken.lexeme)'"
         case .notAFunctionDeclaration:
             return "Error: expected function declaration in class"
         case .notACallableObject:
@@ -75,11 +77,15 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
         case .notALambda:
             return "Error: expected lambda as body of function declaration"
         case .couldNotFindAncestorEnvironmentAtDepth(let depth):
-            return "Error: could not find ancestor environment at depth \(depth)."
+            return "Fatal error: could not find ancestor environment at depth \(depth)."
         case .superclassMustBeAClass:
             return "Error: superclass must be a class"
         case .indexMustBeAnInteger:
             return "Error: index must be a number"
+        case .thisNotResolved:
+            return "Fatal error: `this` not able to be resolved"
+        case .standardLibraryFailedToLoad:
+            return "Fatal error: standard library failed to load properly"
         }
     }
 }

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -26,7 +26,7 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case onlyInstancesHaveProperties(Token)
     case undefinedProperty(Token)
     case wrongArity(Int, Int)
-    case superclassMustBeAClass
+    case superclassMustBeAClass(Token)
     case indexMustBeAnInteger
     case thisNotResolved
 
@@ -68,8 +68,8 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(nameToken.line)] Error: undefined property '\(nameToken.lexeme)'"
         case .wrongArity(let expected, let actual):
             return "Error: incorrect number of arguments; expected \(expected), got \(actual)"
-        case .superclassMustBeAClass:
-            return "Fatal error: superclass must be a class"
+        case .superclassMustBeAClass(let locToken):
+            return "[Line \(locToken.line)] Error: can only subclass from another class"
         case .indexMustBeAnInteger:
             return "Error: index must be a number"
         case .thisNotResolved:

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -14,8 +14,7 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case binaryOperandsMustBeNumbersOrStringsOrLists(Token)
     case unsupportedBinaryOperator(Token)
     case undefinedVariable(Token)
-    case notAFunctionDeclaration
-    case notACallableObject
+    case notACallableObject(Token)
     case notAnInstance
     case notAList
     case notADictionary
@@ -27,8 +26,6 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case onlyInstancesHaveProperties(Token)
     case undefinedProperty(Token)
     case wrongArity(Int, Int)
-    case notALambda
-    case couldNotFindAncestorEnvironmentAtDepth(Int)
     case superclassMustBeAClass
     case indexMustBeAnInteger
     case thisNotResolved
@@ -47,10 +44,8 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(locToken.line)] Error: unsupported binary operator"
         case .undefinedVariable(let nameToken):
             return "[Line \(nameToken.line)] Error: undefined variable '\(nameToken.lexeme)'"
-        case .notAFunctionDeclaration:
-            return "Fatal error: expected function declaration in class"
-        case .notACallableObject:
-            return "Fatal error: expected a callable object"
+        case .notACallableObject(let locToken):
+            return "[Line \(locToken.line)] Error: expected a callable object"
         case .notAnInstance:
             return "Error: expected an instance"
         case .notAList:
@@ -73,10 +68,6 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(nameToken.line)] Error: undefined property '\(nameToken.lexeme)'"
         case .wrongArity(let expected, let actual):
             return "Error: incorrect number of arguments; expected \(expected), got \(actual)"
-        case .notALambda:
-            return "Fatal error: expected lambda as body of function declaration"
-        case .couldNotFindAncestorEnvironmentAtDepth(let depth):
-            return "Fatal error: could not find ancestor environment at depth \(depth)."
         case .superclassMustBeAClass:
             return "Fatal error: superclass must be a class"
         case .indexMustBeAnInteger:

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -49,9 +49,9 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
         case .undefinedVariable(let nameToken):
             return "[Line \(nameToken.line)] Error: undefined variable '\(nameToken.lexeme)'"
         case .notAFunctionDeclaration:
-            return "Error: expected function declaration in class"
+            return "Fatal error: expected function declaration in class"
         case .notACallableObject:
-            return "Error: expected a callable object"
+            return "Fatal error: expected a callable object"
         case .notAnInstance:
             return "Error: expected an instance"
         case .notAList:
@@ -75,11 +75,11 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
         case .wrongArity(let expected, let actual):
             return "Error: incorrect number of arguments; expected \(expected), got \(actual)"
         case .notALambda:
-            return "Error: expected lambda as body of function declaration"
+            return "Fatal error: expected lambda as body of function declaration"
         case .couldNotFindAncestorEnvironmentAtDepth(let depth):
             return "Fatal error: could not find ancestor environment at depth \(depth)."
         case .superclassMustBeAClass:
-            return "Error: superclass must be a class"
+            return "Fatal error: superclass must be a class"
         case .indexMustBeAnInteger:
             return "Error: index must be a number"
         case .thisNotResolved:

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -28,7 +28,6 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case wrongArity(Int, Int)
     case superclassMustBeAClass(Token)
     case indexMustBeAnInteger(Token?)
-    case thisNotResolved
 
     indirect case errorInCall(RuntimeError, Token)
 
@@ -76,8 +75,7 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(locToken.line)] Error: index must be an integer"
         case .indexMustBeAnInteger(nil):
             return "Error: index must be an integer"
-        case .thisNotResolved:
-            return "Fatal error: `this` not able to be resolved"
+
         case .errorInCall(let underlyingError, let nameToken):
             return underlyingError.description + "\n    [Line \(nameToken.line)] in call to \(nameToken.lexeme)()"
         }

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -32,7 +32,6 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case superclassMustBeAClass
     case indexMustBeAnInteger
     case thisNotResolved
-    case standardLibraryFailedToLoad
 
     var description: String {
         switch self {
@@ -84,8 +83,6 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "Error: index must be a number"
         case .thisNotResolved:
             return "Fatal error: `this` not able to be resolved"
-        case .standardLibraryFailedToLoad:
-            return "Fatal error: standard library failed to load properly"
         }
     }
 }

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -27,8 +27,10 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case undefinedProperty(Token)
     case wrongArity(Int, Int)
     case superclassMustBeAClass(Token)
-    case indexMustBeAnInteger
+    case indexMustBeAnInteger(Token?)
     case thisNotResolved
+
+    indirect case errorInCall(RuntimeError, Token)
 
     var description: String {
         switch self {
@@ -70,10 +72,14 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "Error: incorrect number of arguments; expected \(expected), got \(actual)"
         case .superclassMustBeAClass(let locToken):
             return "[Line \(locToken.line)] Error: can only subclass from another class"
-        case .indexMustBeAnInteger:
-            return "Error: index must be a number"
+        case .indexMustBeAnInteger(let locToken?):
+            return "[Line \(locToken.line)] Error: index must be an integer"
+        case .indexMustBeAnInteger(nil):
+            return "Error: index must be an integer"
         case .thisNotResolved:
             return "Fatal error: `this` not able to be resolved"
+        case .errorInCall(let underlyingError, let nameToken):
+            return underlyingError.description + "\n    [Line \(nameToken.line)] in call to \(nameToken.lexeme)()"
         }
     }
 }

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -24,8 +24,8 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case notAString
     case notAnInt
     case notADouble
-    case onlyInstancesHaveProperties
-    case undefinedProperty(String)
+    case onlyInstancesHaveProperties(Token)
+    case undefinedProperty(Token)
     case wrongArity(Int, Int)
     case notALambda
     case couldNotFindAncestorEnvironmentAtDepth(Int)
@@ -68,10 +68,10 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "Error: expected an integer"
         case .notADouble:
             return "Error: expected a double"
-        case .onlyInstancesHaveProperties:
-            return "Error: can only get/set properties of instances"
-        case .undefinedProperty(let name):
-            return "Error: undefined property '\(name)'"
+        case .onlyInstancesHaveProperties(let locToken):
+            return "[Line \(locToken.line)] Error: can only get/set properties of instances"
+        case .undefinedProperty(let nameToken):
+            return "[Line \(nameToken.line)] Error: undefined property '\(nameToken.lexeme)'"
         case .wrongArity(let expected, let actual):
             return "Error: incorrect number of arguments; expected \(expected), got \(actual)"
         case .notALambda:

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -15,9 +15,7 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case unsupportedBinaryOperator(Token)
     case undefinedVariable(Token)
     case notACallableObject(Token)
-    case notAnInstance
     case notAList(Token)
-    case notADictionary
     case notAListOrDictionary(Token)
     case notANumber
     case notAString
@@ -25,7 +23,7 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case notADouble
     case onlyInstancesHaveProperties(Token)
     case undefinedProperty(Token)
-    case wrongArity(Int, Int)
+    case wrongArity(Token, Int, Int)
     case superclassMustBeAClass(Token)
     case indexMustBeAnInteger(Token?)
 
@@ -47,12 +45,8 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(nameToken.line)] Error: undefined variable '\(nameToken.lexeme)'"
         case .notACallableObject(let locToken):
             return "[Line \(locToken.line)] Error: expected a callable object"
-        case .notAnInstance:
-            return "Error: expected an instance"
         case .notAList(let locToken):
             return "[Line \(locToken.line)] Error: expected a list"
-        case .notADictionary:
-            return "Error: expected a dictionary"
         case .notAListOrDictionary(let locToken):
             return "[Line \(locToken.line)] Error: expected a list or dictionary"
         case .notANumber:
@@ -67,8 +61,8 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(locToken.line)] Error: can only get/set properties of instances"
         case .undefinedProperty(let nameToken):
             return "[Line \(nameToken.line)] Error: undefined property '\(nameToken.lexeme)'"
-        case .wrongArity(let expected, let actual):
-            return "Error: incorrect number of arguments; expected \(expected), got \(actual)"
+        case .wrongArity(let locToken, let expected, let actual):
+            return "[Line \(locToken.line)] Error: incorrect number of arguments; expected \(expected), got \(actual)"
         case .superclassMustBeAClass(let locToken):
             return "[Line \(locToken.line)] Error: can only subclass from another class"
         case .indexMustBeAnInteger(let locToken?):

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -16,7 +16,7 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case undefinedVariable(Token)
     case notACallableObject(Token)
     case notAnInstance
-    case notAList
+    case notAList(Token)
     case notADictionary
     case notAListOrDictionary(Token)
     case notANumber
@@ -50,8 +50,8 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(locToken.line)] Error: expected a callable object"
         case .notAnInstance:
             return "Error: expected an instance"
-        case .notAList:
-            return "Error: expected a list"
+        case .notAList(let locToken):
+            return "[Line \(locToken.line)] Error: expected a list"
         case .notADictionary:
             return "Error: expected a dictionary"
         case .notAListOrDictionary(let locToken):

--- a/slox/RuntimeError.swift
+++ b/slox/RuntimeError.swift
@@ -17,7 +17,6 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
     case notACallableObject(Token)
     case notAList(Token)
     case notAListOrDictionary(Token)
-    case notANumber
     case notAString
     case notAnInt
     case notADouble
@@ -49,8 +48,6 @@ enum RuntimeError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(locToken.line)] Error: expected a list"
         case .notAListOrDictionary(let locToken):
             return "[Line \(locToken.line)] Error: expected a list or dictionary"
-        case .notANumber:
-            return "Error: expected a number"
         case .notAString:
             return "Error: expected a string"
         case .notAnInt:

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -13,7 +13,7 @@ indirect enum Statement<Depth: Equatable>: Equatable {
     case variableDeclaration(Token, Expression<Depth>?)
     case block(Token, [Statement])
     case `while`(Token, Expression<Depth>, Statement)
-    case `for`(Statement?, Expression<Depth>, Expression<Depth>?, Statement)
+    case `for`(Token, Statement?, Expression<Depth>, Expression<Depth>?, Statement)
     case function(Token, Expression<Depth>)
     case `return`(Token, Expression<Depth>?)
     case `class`(Token, Expression<Depth>?, [Statement], [Statement])
@@ -37,6 +37,8 @@ indirect enum Statement<Depth: Equatable>: Equatable {
             return beginBlockToken
         case .while(let whileToken, _, _):
             return whileToken
+        case .for(let forToken, _, _, _, _):
+            return forToken
         case .function(let nameToken, _):
             return nameToken
         case .return(let returnToken, _):
@@ -49,8 +51,6 @@ indirect enum Statement<Depth: Equatable>: Equatable {
             return breakToken
         case .continue(let continueToken):
             return continueToken
-        default:
-            return Token(type: .eof, lexeme: "", line: 0)
         }
     }
 }

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -9,7 +9,7 @@ indirect enum Statement<Depth: Equatable>: Equatable {
     case expression(Expression<Depth>)
     case `if`(Token, Expression<Depth>, Statement, Statement?)
     case `switch`(Token, Expression<Depth>, [SwitchCaseDeclaration<Depth>])
-    case print(Expression<Depth>)
+    case print(Token, Expression<Depth>)
     case variableDeclaration(Token, Expression<Depth>?)
     case block([Statement])
     case `while`(Expression<Depth>, Statement)
@@ -29,6 +29,8 @@ indirect enum Statement<Depth: Equatable>: Equatable {
             return ifToken
         case .switch(let switchToken, _, _):
             return switchToken
+        case .print(let printToken, _):
+            return printToken
         case .variableDeclaration(let nameToken, _):
             return nameToken
         case .function(let nameToken, _):

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -7,7 +7,7 @@
 
 indirect enum Statement<Depth: Equatable>: Equatable {
     case expression(Expression<Depth>)
-    case `if`(Expression<Depth>, Statement, Statement?)
+    case `if`(Token, Expression<Depth>, Statement, Statement?)
     case `switch`(Token, Expression<Depth>, [SwitchCaseDeclaration<Depth>])
     case print(Expression<Depth>)
     case variableDeclaration(Token, Expression<Depth>?)
@@ -20,4 +20,31 @@ indirect enum Statement<Depth: Equatable>: Equatable {
     case `enum`(Token, [Token], [Statement], [Statement])
     case `break`(Token)
     case `continue`(Token)
+
+    var locToken: Token {
+        switch self {
+        case .expression(let expr):
+            return expr.locToken
+        case .if(let ifToken, _, _, _):
+            return ifToken
+        case .switch(let switchToken, _, _):
+            return switchToken
+        case .variableDeclaration(let nameToken, _):
+            return nameToken
+        case .function(let nameToken, _):
+            return nameToken
+        case .return(let returnToken, _):
+            return returnToken
+        case .class(let nameToken, _, _, _):
+            return nameToken
+        case .enum(let nameToken, _, _, _):
+            return nameToken
+        case .break(let breakToken):
+            return breakToken
+        case .continue(let continueToken):
+            return continueToken
+        default:
+            return Token(type: .eof, lexeme: "", line: 0)
+        }
+    }
 }

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -11,7 +11,7 @@ indirect enum Statement<Depth: Equatable>: Equatable {
     case `switch`(Token, Expression<Depth>, [SwitchCaseDeclaration<Depth>])
     case print(Token, Expression<Depth>)
     case variableDeclaration(Token, Expression<Depth>?)
-    case block([Statement])
+    case block(Token, [Statement])
     case `while`(Expression<Depth>, Statement)
     case `for`(Statement?, Expression<Depth>, Expression<Depth>?, Statement)
     case function(Token, Expression<Depth>)
@@ -33,6 +33,8 @@ indirect enum Statement<Depth: Equatable>: Equatable {
             return printToken
         case .variableDeclaration(let nameToken, _):
             return nameToken
+        case .block(let beginBlockToken, _):
+            return beginBlockToken
         case .function(let nameToken, _):
             return nameToken
         case .return(let returnToken, _):

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -12,7 +12,7 @@ indirect enum Statement<Depth: Equatable>: Equatable {
     case print(Token, Expression<Depth>)
     case variableDeclaration(Token, Expression<Depth>?)
     case block(Token, [Statement])
-    case `while`(Expression<Depth>, Statement)
+    case `while`(Token, Expression<Depth>, Statement)
     case `for`(Statement?, Expression<Depth>, Expression<Depth>?, Statement)
     case function(Token, Expression<Depth>)
     case `return`(Token, Expression<Depth>?)
@@ -35,6 +35,8 @@ indirect enum Statement<Depth: Equatable>: Equatable {
             return nameToken
         case .block(let beginBlockToken, _):
             return beginBlockToken
+        case .while(let whileToken, _, _):
+            return whileToken
         case .function(let nameToken, _):
             return nameToken
         case .return(let returnToken, _):

--- a/slox/Statement.swift
+++ b/slox/Statement.swift
@@ -8,7 +8,7 @@
 indirect enum Statement<Depth: Equatable>: Equatable {
     case expression(Expression<Depth>)
     case `if`(Expression<Depth>, Statement, Statement?)
-    case `switch`(Expression<Depth>, [SwitchCaseDeclaration<Depth>])
+    case `switch`(Token, Expression<Depth>, [SwitchCaseDeclaration<Depth>])
     case print(Expression<Depth>)
     case variableDeclaration(Token, Expression<Depth>?)
     case block([Statement])

--- a/slox/SwitchCaseDeclaration.swift
+++ b/slox/SwitchCaseDeclaration.swift
@@ -6,6 +6,7 @@
 //
 
 struct SwitchCaseDeclaration<Depth: Equatable>: Equatable {
+    var caseToken: Token
     var valueExpressions: [Expression<Depth>]?
     var statement: Statement<Depth>
 }

--- a/slox/UserDefinedFunction.swift
+++ b/slox/UserDefinedFunction.swift
@@ -10,7 +10,7 @@ import Foundation
 struct UserDefinedFunction: LoxCallable, Equatable {
     var name: String
     var enclosingEnvironment: Environment
-    var body: [Statement<Int>]
+    var body: Statement<Int>
     var isInitializer: Bool
     var objectId: UUID
     var parameterList: ParameterList? = nil
@@ -22,7 +22,7 @@ struct UserDefinedFunction: LoxCallable, Equatable {
     init(name: String,
          parameterList: ParameterList?,
          enclosingEnvironment: Environment,
-         body: [Statement<Int>],
+         body: Statement<Int>,
          isInitializer: Bool) {
         self.name = name
         self.parameterList = parameterList
@@ -48,8 +48,14 @@ struct UserDefinedFunction: LoxCallable, Equatable {
             }
         }
 
+        let previousEnvironment = interpreter.environment
+        interpreter.environment = newEnvironment
+        defer {
+            interpreter.environment = previousEnvironment
+        }
         do {
-            try interpreter.handleBlock(statements: body, environment: newEnvironment)
+//            try interpreter.handleBlock(statements: statements, environment: newEnvironment)
+            try interpreter.execute(statement: body)
         } catch JumpType.return(let value) {
             // This is for when we call `init()` explicitly from an instance
             if isInitializer {

--- a/slox/UserDefinedFunction.swift
+++ b/slox/UserDefinedFunction.swift
@@ -54,7 +54,6 @@ struct UserDefinedFunction: LoxCallable, Equatable {
             interpreter.environment = previousEnvironment
         }
         do {
-//            try interpreter.handleBlock(statements: statements, environment: newEnvironment)
             try interpreter.execute(statement: body)
         } catch JumpType.return(let value) {
             // This is for when we call `init()` explicitly from an instance

--- a/slox/UserDefinedFunction.swift
+++ b/slox/UserDefinedFunction.swift
@@ -53,7 +53,8 @@ struct UserDefinedFunction: LoxCallable, Equatable {
         } catch JumpType.return(let value) {
             // This is for when we call `init()` explicitly from an instance
             if isInitializer {
-                return try enclosingEnvironment.getValueAtDepth(name: "this", depth: 0)
+                let dummyThisToken = Token(type: .this, lexeme: "this", line: 0)
+                return try enclosingEnvironment.getValueAtDepth(nameToken: dummyThisToken, depth: 0)
             }
 
             return value
@@ -61,7 +62,8 @@ struct UserDefinedFunction: LoxCallable, Equatable {
 
         // This is for when we call `init()` implicitly through a class constructor
         if isInitializer {
-            return try enclosingEnvironment.getValueAtDepth(name: "this", depth: 0)
+            let dummyThisToken = Token(type: .this, lexeme: "this", line: 0)
+            return try enclosingEnvironment.getValueAtDepth(nameToken: dummyThisToken, depth: 0)
         }
 
         return .nil

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -328,7 +328,8 @@ sum(*foo, 4, 5)
 """
 
         let interpreter = Interpreter()
-        let expectedError = RuntimeError.wrongArity(3, 5)
+        let locToken = Token(type: .identifier, lexeme: "sum", line: 5)
+        let expectedError = RuntimeError.wrongArity(locToken, 3, 5)
         XCTAssertThrowsError(try interpreter.interpretRepl(source: input)!) { actualError in
             XCTAssertEqual(actualError as! RuntimeError, expectedError)
         }

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -573,7 +573,8 @@ foo[2.0]
 """
 
         let interpreter = Interpreter()
-        let expectedError = RuntimeError.indexMustBeAnInteger
+        let locToken = Token(type: .double, lexeme: "2.0", line: 2)
+        let expectedError = RuntimeError.indexMustBeAnInteger(locToken)
         XCTAssertThrowsError(try interpreter.interpretRepl(source: input)!) { actualError in
             XCTAssertEqual(actualError as! RuntimeError, expectedError)
         }

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -434,7 +434,8 @@ person.name
 """
 
         let interpreter = Interpreter()
-        let expectedError = RuntimeError.undefinedProperty("name")
+        let nameToken = Token(type: .identifier, lexeme: "name", line: 3)
+        let expectedError = RuntimeError.undefinedProperty(nameToken)
         XCTAssertThrowsError(try interpreter.interpretRepl(source: input)!) { actualError in
             XCTAssertEqual(actualError as! RuntimeError, expectedError)
         }

--- a/sloxTests/InterpreterTests.swift
+++ b/sloxTests/InterpreterTests.swift
@@ -44,7 +44,8 @@ final class InterpreterTests: XCTestCase {
         let input = "-\"forty-two\""
         let interpreter = Interpreter()
 
-        let expectedError = RuntimeError.unaryOperandMustBeNumber
+        let locToken = Token(type: .minus, lexeme: "-", line: 1)
+        let expectedError = RuntimeError.unaryOperandMustBeNumber(locToken)
         XCTAssertThrowsError(try interpreter.interpretRepl(source: input)!) { actualError in
             XCTAssertEqual(actualError as! RuntimeError, expectedError)
         }
@@ -102,7 +103,8 @@ final class InterpreterTests: XCTestCase {
         let input = "\"twenty-one\" * 2"
         let interpreter = Interpreter()
 
-        let expectedError = RuntimeError.binaryOperandsMustBeNumbers
+        let locToken = Token(type: .star, lexeme: "*", line: 1)
+        let expectedError = RuntimeError.binaryOperandsMustBeNumbers(locToken)
         XCTAssertThrowsError(try interpreter.interpretRepl(source: input)!) { actualError in
             XCTAssertEqual(actualError as! RuntimeError, expectedError)
         }
@@ -280,7 +282,8 @@ a
 """
 
         let interpreter = Interpreter()
-        let expectedError = RuntimeError.undefinedVariable("a")
+        let locToken = Token(type: .identifier, lexeme: "a", line: 3)
+        let expectedError = RuntimeError.undefinedVariable(locToken)
         XCTAssertThrowsError(try interpreter.interpretRepl(source: input)!) { actualError in
             XCTAssertEqual(actualError as! RuntimeError, expectedError)
         }
@@ -1229,7 +1232,8 @@ answer
 """
 
         let interpreter = Interpreter()
-        let expectedError = RuntimeError.undefinedVariable("answer")
+        let locToken = Token(type: .identifier, lexeme: "answer", line: 6)
+        let expectedError = RuntimeError.undefinedVariable(locToken)
         XCTAssertThrowsError(try interpreter.interpretRepl(source: input)!) { actualError in
             XCTAssertEqual(actualError as! RuntimeError, expectedError)
         }

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -921,6 +921,7 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .while(
+                Token(type: .while, lexeme: "while", line: 1),
                 .binary(
                     .variable(
                         Token(type: .identifier, lexeme: "x", line: 1),

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -436,7 +436,7 @@ final class ParserTests: XCTestCase {
                     Token(type: .star, lexeme: "*", line: 1),
                     .grouping(
                         Token(type: .leftParen, lexeme: "(", line: 1),
-                        .binary(
+                            .binary(
                             .literal(
                                 Token(type: .int, lexeme: "3", line: 1),
                                 .int(3)),
@@ -1224,17 +1224,19 @@ final class ParserTests: XCTestCase {
                     [
                         .splat(
                             Token(type: .star, lexeme: "*", line: 1),
-                            .list([
-                                .literal(
-                                    Token(type: .int, lexeme: "1", line: 1),
-                                    .int(1)),
-                                .literal(
-                                    Token(type: .int, lexeme: "2", line: 1),
-                                    .int(2)),
-                                .literal(
-                                    Token(type: .int, lexeme: "3", line: 1),
-                                    .int(3)),
-                            ])),
+                            .list(
+                                Token(type: .leftBracket, lexeme: "[", line: 1),
+                                [
+                                    .literal(
+                                        Token(type: .int, lexeme: "1", line: 1),
+                                        .int(1)),
+                                    .literal(
+                                        Token(type: .int, lexeme: "2", line: 1),
+                                        .int(2)),
+                                    .literal(
+                                        Token(type: .int, lexeme: "3", line: 1),
+                                        .int(3)),
+                                ])),
                     ])),
         ]
         XCTAssertEqual(actual, expected)
@@ -1618,15 +1620,17 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
-                .list([
-                    .literal(
-                        Token(type: .int, lexeme: "1", line: 1),
-                        .int(1)),
-                    .string(Token(type: .string, lexeme: "\"one\"", line: 1)),
-                    .literal(
-                        Token(type: .true, lexeme: "true", line: 1),
-                        .boolean(true))
-                ]))
+                .list(
+                    Token(type: .leftBracket, lexeme: "[", line: 1),
+                    [
+                        .literal(
+                            Token(type: .int, lexeme: "1", line: 1),
+                            .int(1)),
+                        .string(Token(type: .string, lexeme: "\"one\"", line: 1)),
+                        .literal(
+                            Token(type: .true, lexeme: "true", line: 1),
+                            .boolean(true))
+                    ]))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -1663,8 +1667,9 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
-                .list([
-                ]))
+                .list(
+                    Token(type: .leftBracket, lexeme: "[", line: 1),
+                    []))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -1682,7 +1687,9 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
-                .dictionary([]))
+                .dictionary(
+                    Token(type: .leftBracket, lexeme: "[", line: 1),
+                    []))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -1702,9 +1709,11 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
-                .dictionary([
-                    (.string(Token(type: .string, lexeme: "\"a\"", line: 1)), .literal(Token(type: .int, lexeme: "1", line: 1),.int(1))),
-                ]))
+                .dictionary(
+                    Token(type: .leftBracket, lexeme: "[", line: 1),
+                    [
+                        (.string(Token(type: .string, lexeme: "\"a\"", line: 1)), .literal(Token(type: .int, lexeme: "1", line: 1),.int(1))),
+                    ]))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -1732,11 +1741,13 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
-                .dictionary([
-                    (.string(Token(type: .string, lexeme: "\"a\"", line: 1)), .literal(Token(type: .int, lexeme: "1", line: 1),.int(1))),
-                    (.string(Token(type: .string, lexeme: "\"b\"", line: 1)), .literal(Token(type: .int, lexeme: "2", line: 1),.int(2))),
-                    (.string(Token(type: .string, lexeme: "\"c\"", line: 1)), .literal(Token(type: .int, lexeme: "3", line: 1),.int(3))),
-                ]))
+                .dictionary(
+                    Token(type: .leftBracket, lexeme: "[", line: 1),
+                    [
+                        (.string(Token(type: .string, lexeme: "\"a\"", line: 1)), .literal(Token(type: .int, lexeme: "1", line: 1),.int(1))),
+                        (.string(Token(type: .string, lexeme: "\"b\"", line: 1)), .literal(Token(type: .int, lexeme: "2", line: 1),.int(2))),
+                        (.string(Token(type: .string, lexeme: "\"c\"", line: 1)), .literal(Token(type: .int, lexeme: "3", line: 1),.int(3))),
+                    ]))
         ]
         XCTAssertEqual(actual, expected)
     }

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -844,18 +844,20 @@ final class ParserTests: XCTestCase {
 
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
-            .block([
-                .variableDeclaration(
-                    Token(type: .identifier, lexeme: "theAnswer", line: 2),
-                    .literal(
-                        Token(type: .int, lexeme: "42", line: 2),
-                        .int(42))),
-                .print(
-                    Token(type: .print, lexeme: "print", line: 3),
-                    .variable(
-                        Token(type: .identifier, lexeme: "theAnswer", line: 3),
-                        UnresolvedDepth())),
-            ]),
+            .block(
+                Token(type: .leftBrace, lexeme: "{", line: 1),
+                [
+                    .variableDeclaration(
+                        Token(type: .identifier, lexeme: "theAnswer", line: 2),
+                        .literal(
+                            Token(type: .int, lexeme: "42", line: 2),
+                            .int(42))),
+                    .print(
+                        Token(type: .print, lexeme: "print", line: 3),
+                        .variable(
+                            Token(type: .identifier, lexeme: "theAnswer", line: 3),
+                            UnresolvedDepth())),
+                ]),
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -927,25 +929,27 @@ final class ParserTests: XCTestCase {
                     .literal(
                         Token(type: .int, lexeme: "5", line: 1),
                         .int(5))),
-                .block([
-                    .print(
-                        Token(type: .print, lexeme: "print", line: 2),
-                        .variable(
-                            Token(type: .identifier, lexeme: "x", line: 2),
-                            UnresolvedDepth())),
-                    .expression(
-                        .assignment(
-                            Token(type: .identifier, lexeme: "x", line: 3),
-                            .binary(
-                                .variable(
-                                    Token(type: .identifier, lexeme: "x", line: 3),
-                                    UnresolvedDepth()),
-                                Token(type: .plus, lexeme: "+", line: 3),
-                                .literal(
-                                    Token(type: .int, lexeme: "1", line: 3),
-                                    .int(1))),
-                            UnresolvedDepth())),
-                ]))
+                .block(
+                    Token(type: .leftBrace, lexeme: "{", line: 1),
+                    [
+                        .print(
+                            Token(type: .print, lexeme: "print", line: 2),
+                            .variable(
+                                Token(type: .identifier, lexeme: "x", line: 2),
+                                UnresolvedDepth())),
+                        .expression(
+                            .assignment(
+                                Token(type: .identifier, lexeme: "x", line: 3),
+                                .binary(
+                                    .variable(
+                                        Token(type: .identifier, lexeme: "x", line: 3),
+                                        UnresolvedDepth()),
+                                    Token(type: .plus, lexeme: "+", line: 3),
+                                    .literal(
+                                        Token(type: .int, lexeme: "1", line: 3),
+                                        .int(1))),
+                                UnresolvedDepth())),
+                    ]))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -1000,13 +1004,15 @@ final class ParserTests: XCTestCase {
                 .lambda(
                     Token(type: .identifier, lexeme: "theAnswer", line: 1),
                     ParameterList(normalParameters: []),
-                    .block([
-                        .print(
-                            Token(type: .print, lexeme: "print", line: 2),
-                            .literal(
-                                Token(type: .int, lexeme: "42", line: 2),
-                                .int(42)))
-                    ]))),
+                    .block(
+                        Token(type: .leftBrace, lexeme: "{", line: 1),
+                        [
+                            .print(
+                                Token(type: .print, lexeme: "print", line: 2),
+                                .literal(
+                                    Token(type: .int, lexeme: "42", line: 2),
+                                    .int(42)))
+                        ]))),
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -1046,18 +1052,20 @@ final class ParserTests: XCTestCase {
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
                     ]),
-                    .block([
-                        .return(
-                            Token(type: .return, lexeme: "return", line: 2),
-                            .binary(
-                                .variable(
-                                    Token(type: .identifier, lexeme: "a", line: 2),
-                                    UnresolvedDepth()),
-                                Token(type: .plus, lexeme: "+", line: 2),
-                                .variable(
-                                    Token(type: .identifier, lexeme: "b", line: 2),
-                                    UnresolvedDepth())))
-                    ]))
+                    .block(
+                        Token(type: .leftBrace, lexeme: "{", line: 1),
+                        [
+                            .return(
+                                Token(type: .return, lexeme: "return", line: 2),
+                                .binary(
+                                    .variable(
+                                        Token(type: .identifier, lexeme: "a", line: 2),
+                                        UnresolvedDepth()),
+                                    Token(type: .plus, lexeme: "+", line: 2),
+                                    .variable(
+                                        Token(type: .identifier, lexeme: "b", line: 2),
+                                        UnresolvedDepth())))
+                        ]))
             )
         ]
         XCTAssertEqual(actual, expected)
@@ -1098,13 +1106,15 @@ final class ParserTests: XCTestCase {
                             Token(type: .identifier, lexeme: "a", line: 1),
                         ],
                         variadicParameter: Token(type: .identifier, lexeme: "b", line: 1)),
-                    .block([
-                        .return(
-                            Token(type: .return, lexeme: "return", line: 2),
-                            .variable(
-                                Token(type: .identifier, lexeme: "b", line: 2),
-                                UnresolvedDepth()))
-                    ]))
+                    .block(
+                        Token(type: .leftBrace, lexeme: "{", line: 1),
+                        [
+                            .return(
+                                Token(type: .return, lexeme: "return", line: 2),
+                                .variable(
+                                    Token(type: .identifier, lexeme: "b", line: 2),
+                                    UnresolvedDepth()))
+                        ]))
             )
         ]
         XCTAssertEqual(actual, expected)
@@ -1287,18 +1297,20 @@ final class ParserTests: XCTestCase {
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
                     ]),
-                    .block([
-                        .return(
-                            Token(type: .return, lexeme: "return", line: 1),
-                            .binary(
-                                .variable(
-                                    Token(type: .identifier, lexeme: "a", line: 1),
-                                    UnresolvedDepth()),
-                                Token(type: .plus, lexeme: "+", line: 1),
-                                .variable(
-                                    Token(type: .identifier, lexeme: "b", line: 1),
-                                    UnresolvedDepth()))),
-                    ])))
+                    .block(
+                        Token(type: .leftBrace, lexeme: "{", line: 1),
+                        [
+                            .return(
+                                Token(type: .return, lexeme: "return", line: 1),
+                                .binary(
+                                    .variable(
+                                        Token(type: .identifier, lexeme: "a", line: 1),
+                                        UnresolvedDepth()),
+                                    Token(type: .plus, lexeme: "+", line: 1),
+                                    .variable(
+                                        Token(type: .identifier, lexeme: "b", line: 1),
+                                        UnresolvedDepth()))),
+                        ])))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -1343,16 +1355,18 @@ final class ParserTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "sayName", line: 2),
                             ParameterList(normalParameters: []),
-                            .block([
-                                .print(
-                                    Token(type: .print, lexeme: "print", line: 3),
-                                    .get(
-                                        Token(type: .dot, lexeme: ".", line: 3),
-                                        .this(
-                                            Token(type: .this, lexeme: "this", line: 3),
-                                            UnresolvedDepth()),
-                                        Token(type: .identifier, lexeme: "name", line: 3)))
-                            ])))
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .print(
+                                        Token(type: .print, lexeme: "print", line: 3),
+                                        .get(
+                                            Token(type: .dot, lexeme: ".", line: 3),
+                                            .this(
+                                                Token(type: .this, lexeme: "this", line: 3),
+                                                UnresolvedDepth()),
+                                            Token(type: .identifier, lexeme: "name", line: 3)))
+                                ])))
                 ],
                 [])
         ]
@@ -1458,18 +1472,20 @@ final class ParserTests: XCTestCase {
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
                             ]),
-                            .block([
-                                .return(
-                                    Token(type: .return, lexeme: "return", line: 3),
-                                    .binary(
-                                        .variable(
-                                            Token(type: .identifier, lexeme: "a", line: 3),
-                                            UnresolvedDepth()),
-                                        Token(type: .plus, lexeme: "+", line: 3),
-                                        .variable(
-                                            Token(type: .identifier, lexeme: "b", line: 3),
-                                            UnresolvedDepth())))
-                            ])))
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .return(
+                                        Token(type: .return, lexeme: "return", line: 3),
+                                        .binary(
+                                            .variable(
+                                                Token(type: .identifier, lexeme: "a", line: 3),
+                                                UnresolvedDepth()),
+                                            Token(type: .plus, lexeme: "+", line: 3),
+                                            .variable(
+                                                Token(type: .identifier, lexeme: "b", line: 3),
+                                                UnresolvedDepth())))
+                                ])))
                 ])
         ]
         XCTAssertEqual(actual, expected)
@@ -1525,21 +1541,23 @@ final class ParserTests: XCTestCase {
                             ParameterList(normalParameters: [
                                 Token(type: .identifier, lexeme: "arg", line: 2)
                             ]),
-                            .block([
-                                .return(
-                                    Token(type: .return, lexeme: "return", line: 3),
-                                    .call(
-                                        .super(
-                                            Token(type: .super, lexeme: "super", line: 3),
-                                            Token(type: .identifier, lexeme: "someMethod", line: 3),
-                                            UnresolvedDepth()),
-                                        Token(type: .rightParen, lexeme: ")", line: 3),
-                                        [
-                                            .variable(
-                                                Token(type: .identifier, lexeme: "arg", line: 3),
-                                                UnresolvedDepth())
-                                        ]))
-                            ])))
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .return(
+                                        Token(type: .return, lexeme: "return", line: 3),
+                                        .call(
+                                            .super(
+                                                Token(type: .super, lexeme: "super", line: 3),
+                                                Token(type: .identifier, lexeme: "someMethod", line: 3),
+                                                UnresolvedDepth()),
+                                            Token(type: .rightParen, lexeme: ")", line: 3),
+                                            [
+                                                .variable(
+                                                    Token(type: .identifier, lexeme: "arg", line: 3),
+                                                    UnresolvedDepth())
+                                            ]))
+                                ])))
                 ],
                 []),
         ]
@@ -1590,29 +1608,31 @@ final class ParserTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "area", line: 2),
                             nil,
-                            .block([
-                                .return(
-                                    Token(type: .return, lexeme: "return", line: 3),
-                                    .binary(
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .return(
+                                        Token(type: .return, lexeme: "return", line: 3),
                                         .binary(
-                                            .literal(
-                                                Token(type: .double, lexeme: "3.14159", line: 3),
-                                                .double(3.14159)),
+                                            .binary(
+                                                .literal(
+                                                    Token(type: .double, lexeme: "3.14159", line: 3),
+                                                    .double(3.14159)),
+                                                Token(type: .star, lexeme: "*", line: 3),
+                                                .get(
+                                                    Token(type: .dot, lexeme: ".", line: 3),
+                                                    .this(
+                                                        Token(type: .this, lexeme: "this", line: 3),
+                                                        UnresolvedDepth()),
+                                                    Token(type: .identifier, lexeme: "radius", line: 3))),
                                             Token(type: .star, lexeme: "*", line: 3),
                                             .get(
                                                 Token(type: .dot, lexeme: ".", line: 3),
                                                 .this(
                                                     Token(type: .this, lexeme: "this", line: 3),
                                                     UnresolvedDepth()),
-                                                Token(type: .identifier, lexeme: "radius", line: 3))),
-                                        Token(type: .star, lexeme: "*", line: 3),
-                                        .get(
-                                            Token(type: .dot, lexeme: ".", line: 3),
-                                            .this(
-                                                Token(type: .this, lexeme: "this", line: 3),
-                                                UnresolvedDepth()),
-                                            Token(type: .identifier, lexeme: "radius", line: 3)))),
-                            ])))
+                                                Token(type: .identifier, lexeme: "radius", line: 3)))),
+                                ])))
                 ],
                 [])
         ]
@@ -1840,34 +1860,38 @@ final class ParserTests: XCTestCase {
                             ParameterList(
                                 normalParameters: [],
                                 variadicParameter: nil),
-                            .block([
-                                .if(
-                                    Token(type: .if, lexeme: "if", line: 4),
-                                    .binary(
-                                        .this(
-                                            Token(type: .this, lexeme: "this", line: 4),
-                                            UnresolvedDepth()),
-                                        Token(type: .equalEqual, lexeme: "==", line: 4),
-                                        .get(
-                                            Token(type: .dot, lexeme: ".", line: 4),
-                                            .variable(
-                                                Token(type: .identifier, lexeme: "Foo", line: 4),
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 3),
+                                [
+                                    .if(
+                                        Token(type: .if, lexeme: "if", line: 4),
+                                        .binary(
+                                            .this(
+                                                Token(type: .this, lexeme: "this", line: 4),
                                                 UnresolvedDepth()),
-                                            Token(type: .identifier, lexeme: "bar", line: 4))),
-                                    .block([
-                                        .return(
-                                            Token(type: .return, lexeme: "return", line: 5),
-                                            .literal(
-                                                Token(type: .true, lexeme: "true", line: 5),
-                                                .boolean(true))),
-                                    ]),
-                                    nil),
-                                .return(
-                                    Token(type: .return, lexeme: "return", line: 7),
-                                    .literal(
-                                        Token(type: .false, lexeme: "false", line: 7),
-                                        .boolean(false)))
-                            ])))
+                                            Token(type: .equalEqual, lexeme: "==", line: 4),
+                                            .get(
+                                                Token(type: .dot, lexeme: ".", line: 4),
+                                                .variable(
+                                                    Token(type: .identifier, lexeme: "Foo", line: 4),
+                                                    UnresolvedDepth()),
+                                                Token(type: .identifier, lexeme: "bar", line: 4))),
+                                        .block(
+                                            Token(type: .leftBrace, lexeme: "{", line: 4),
+                                            [
+                                                .return(
+                                                    Token(type: .return, lexeme: "return", line: 5),
+                                                    .literal(
+                                                        Token(type: .true, lexeme: "true", line: 5),
+                                                        .boolean(true))),
+                                            ]),
+                                        nil),
+                                    .return(
+                                        Token(type: .return, lexeme: "return", line: 7),
+                                        .literal(
+                                            Token(type: .false, lexeme: "false", line: 7),
+                                            .boolean(false)))
+                                ])))
                 ],
                 []),
         ]
@@ -1947,11 +1971,13 @@ final class ParserTests: XCTestCase {
                                 Token(type: .int, lexeme: "1", line: 2),
                                 .int(1))
                         ],
-                        statement: .block([
-                            .print(
-                                Token(type: .print, lexeme: "print", line: 3),
-                                .string(Token(type: .string, lexeme: "\"one\"", line: 3)))
-                        ])),
+                        statement: .block(
+                            Token(type: .colon, lexeme: ":", line: 2),
+                            [
+                                .print(
+                                    Token(type: .print, lexeme: "print", line: 3),
+                                    .string(Token(type: .string, lexeme: "\"one\"", line: 3)))
+                            ])),
                     SwitchCaseDeclaration(
                         caseToken: Token(type: .case, lexeme: "case", line: 4),
                         valueExpressions: [
@@ -1965,24 +1991,28 @@ final class ParserTests: XCTestCase {
                                 Token(type: .int, lexeme: "4", line: 4),
                                 .int(4)),
                         ],
-                        statement: .block([
-                            .print(
-                                Token(type: .print, lexeme: "print", line: 5),
-                                .string(Token(type: .string, lexeme: "\"two\"", line: 5))),
-                            .print(
-                                Token(type: .print, lexeme: "print", line: 6),
-                                .string(Token(type: .string, lexeme: "\"three\"", line: 6))),
-                            .print(
-                                Token(type: .print, lexeme: "print", line: 7),
-                                .string(Token(type: .string, lexeme: "\"or four\"", line: 7)))
-                        ])),
+                        statement: .block(
+                            Token(type: .colon, lexeme: ":", line: 4),
+                            [
+                                .print(
+                                    Token(type: .print, lexeme: "print", line: 5),
+                                    .string(Token(type: .string, lexeme: "\"two\"", line: 5))),
+                                .print(
+                                    Token(type: .print, lexeme: "print", line: 6),
+                                    .string(Token(type: .string, lexeme: "\"three\"", line: 6))),
+                                .print(
+                                    Token(type: .print, lexeme: "print", line: 7),
+                                    .string(Token(type: .string, lexeme: "\"or four\"", line: 7)))
+                            ])),
                     SwitchCaseDeclaration(
                         caseToken: Token(type: .default, lexeme: "default", line: 8),
-                        statement: .block([
-                            .print(
-                                Token(type: .print, lexeme: "print", line: 9),
-                                .string(Token(type: .string, lexeme: "\"unhandled\"", line: 9))),
-                        ])),
+                        statement: .block(
+                            Token(type: .colon, lexeme: ":", line: 8),
+                            [
+                                .print(
+                                    Token(type: .print, lexeme: "print", line: 9),
+                                    .string(Token(type: .string, lexeme: "\"unhandled\"", line: 9))),
+                            ])),
                 ])
         ]
         XCTAssertEqual(actual, expected)

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -1000,13 +1000,13 @@ final class ParserTests: XCTestCase {
                 .lambda(
                     Token(type: .identifier, lexeme: "theAnswer", line: 1),
                     ParameterList(normalParameters: []),
-                    [
+                    .block([
                         .print(
                             Token(type: .print, lexeme: "print", line: 2),
                             .literal(
                                 Token(type: .int, lexeme: "42", line: 2),
                                 .int(42)))
-                    ])),
+                    ]))),
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -1046,7 +1046,7 @@ final class ParserTests: XCTestCase {
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
                     ]),
-                    [
+                    .block([
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
                             .binary(
@@ -1057,7 +1057,7 @@ final class ParserTests: XCTestCase {
                                 .variable(
                                     Token(type: .identifier, lexeme: "b", line: 2),
                                     UnresolvedDepth())))
-                    ])
+                    ]))
             )
         ]
         XCTAssertEqual(actual, expected)
@@ -1098,13 +1098,13 @@ final class ParserTests: XCTestCase {
                             Token(type: .identifier, lexeme: "a", line: 1),
                         ],
                         variadicParameter: Token(type: .identifier, lexeme: "b", line: 1)),
-                    [
+                    .block([
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
                             .variable(
                                 Token(type: .identifier, lexeme: "b", line: 2),
                                 UnresolvedDepth()))
-                    ])
+                    ]))
             )
         ]
         XCTAssertEqual(actual, expected)
@@ -1287,7 +1287,7 @@ final class ParserTests: XCTestCase {
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
                     ]),
-                    [
+                    .block([
                         .return(
                             Token(type: .return, lexeme: "return", line: 1),
                             .binary(
@@ -1298,7 +1298,7 @@ final class ParserTests: XCTestCase {
                                 .variable(
                                     Token(type: .identifier, lexeme: "b", line: 1),
                                     UnresolvedDepth()))),
-                    ]))
+                    ])))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -1343,7 +1343,7 @@ final class ParserTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "sayName", line: 2),
                             ParameterList(normalParameters: []),
-                            [
+                            .block([
                                 .print(
                                     Token(type: .print, lexeme: "print", line: 3),
                                     .get(
@@ -1352,7 +1352,7 @@ final class ParserTests: XCTestCase {
                                             Token(type: .this, lexeme: "this", line: 3),
                                             UnresolvedDepth()),
                                         Token(type: .identifier, lexeme: "name", line: 3)))
-                            ]))
+                            ])))
                 ],
                 [])
         ]
@@ -1458,7 +1458,7 @@ final class ParserTests: XCTestCase {
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
                             ]),
-                            [
+                            .block([
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
                                     .binary(
@@ -1469,7 +1469,7 @@ final class ParserTests: XCTestCase {
                                         .variable(
                                             Token(type: .identifier, lexeme: "b", line: 3),
                                             UnresolvedDepth())))
-                            ]))
+                            ])))
                 ])
         ]
         XCTAssertEqual(actual, expected)
@@ -1525,7 +1525,7 @@ final class ParserTests: XCTestCase {
                             ParameterList(normalParameters: [
                                 Token(type: .identifier, lexeme: "arg", line: 2)
                             ]),
-                            [
+                            .block([
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
                                     .call(
@@ -1539,7 +1539,7 @@ final class ParserTests: XCTestCase {
                                                 Token(type: .identifier, lexeme: "arg", line: 3),
                                                 UnresolvedDepth())
                                         ]))
-                            ]))
+                            ])))
                 ],
                 []),
         ]
@@ -1590,7 +1590,7 @@ final class ParserTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "area", line: 2),
                             nil,
-                            [
+                            .block([
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
                                     .binary(
@@ -1612,7 +1612,7 @@ final class ParserTests: XCTestCase {
                                                 Token(type: .this, lexeme: "this", line: 3),
                                                 UnresolvedDepth()),
                                             Token(type: .identifier, lexeme: "radius", line: 3)))),
-                            ]))
+                            ])))
                 ],
                 [])
         ]
@@ -1840,7 +1840,7 @@ final class ParserTests: XCTestCase {
                             ParameterList(
                                 normalParameters: [],
                                 variadicParameter: nil),
-                            [
+                            .block([
                                 .if(
                                     Token(type: .if, lexeme: "if", line: 4),
                                     .binary(
@@ -1867,7 +1867,7 @@ final class ParserTests: XCTestCase {
                                     .literal(
                                         Token(type: .false, lexeme: "false", line: 7),
                                         .boolean(false)))
-                            ]))
+                            ])))
                 ],
                 []),
         ]

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -33,7 +33,10 @@ final class ParserTests: XCTestCase {
 
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
-            .expression(.literal(.double(123.456)))
+            .expression(
+                .literal(
+                    Token(type: .double, lexeme: "123.456", line: 1),
+                    .double(123.456)))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -48,7 +51,10 @@ final class ParserTests: XCTestCase {
 
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
-            .expression(.literal(.boolean(true)))
+            .expression(
+                .literal(
+                    Token(type: .true, lexeme: "true", line: 1),
+                    .boolean(true)))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -63,7 +69,10 @@ final class ParserTests: XCTestCase {
 
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
-            .expression(.literal(.nil))
+            .expression(
+                .literal(
+                    Token(type: .nil, lexeme: "nil", line: 1),
+                    .nil))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -80,7 +89,11 @@ final class ParserTests: XCTestCase {
 
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
-            .expression(.grouping(.literal(.int(42))))
+            .expression(
+                .grouping(
+                    .literal(
+                        Token(type: .int, lexeme: "42", line: 1),
+                        .int(42))))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -132,7 +145,9 @@ final class ParserTests: XCTestCase {
             .expression(
                 .unary(
                     Token(type: .bang, lexeme: "!", line: 1),
-                    .literal(.boolean(true))))
+                    .literal(
+                        Token(type: .true, lexeme: "true", line: 1),
+                        .boolean(true))))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -151,9 +166,13 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .binary(
-                    .literal(.int(21)),
+                    .literal(
+                        Token(type: .int, lexeme: "21", line: 1),
+                        .int(21)),
                     Token(type: .star, lexeme: "*", line: 1),
-                    .literal(.int(2))))
+                    .literal(
+                        Token(type: .int, lexeme: "2", line: 1),
+                        .int(2))))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -172,9 +191,13 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .binary(
-                    .literal(.int(5)),
+                    .literal(
+                        Token(type: .int, lexeme: "5", line: 1),
+                        .int(5)),
                     Token(type: .modulus, lexeme: "%", line: 1),
-                    .literal(.int(3))))
+                    .literal(
+                        Token(type: .int, lexeme: "3", line: 1),
+                        .int(3))))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -214,9 +237,13 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .binary(
-                    .literal(.int(1)),
+                    .literal(
+                        Token(type: .int, lexeme: "1", line: 1),
+                        .int(1)),
                     Token(type: .lessEqual, lexeme: "<=", line: 1),
-                    .literal(.int(2))))
+                    .literal(
+                        Token(type: .int, lexeme: "2", line: 1),
+                        .int(2))))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -237,7 +264,9 @@ final class ParserTests: XCTestCase {
                 .binary(
                     .string(Token(type: .string, lexeme: "\"forty-two\"", line: 1)),
                     Token(type: .equalEqual, lexeme: "==", line: 1),
-                    .literal(.nil)))
+                    .literal(
+                        Token(type: .nil, lexeme: "nil", line: 1),
+                        .nil)))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -254,9 +283,14 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
-                .logical(.literal(.boolean(true)),
-                         Token(type: .or, lexeme: "or", line: 1),
-                         .literal(.boolean(false))))
+                .logical(
+                    .literal(
+                        Token(type: .true, lexeme: "true", line: 1),
+                        .boolean(true)),
+                    Token(type: .or, lexeme: "or", line: 1),
+                    .literal(
+                        Token(type: .false, lexeme: "false", line: 1),
+                        .boolean(false))))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -273,9 +307,14 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
-                .logical(.literal(.boolean(true)),
-                         Token(type: .and, lexeme: "and", line: 1),
-                         .literal(.boolean(false))))
+                .logical(
+                    .literal(
+                        Token(type: .true, lexeme: "true", line: 1),
+                        .boolean(true)),
+                    Token(type: .and, lexeme: "and", line: 1),
+                    .literal(
+                        Token(type: .false, lexeme: "false", line: 1),
+                        .boolean(false))))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -294,11 +333,19 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
-                .logical(.logical(.literal(.boolean(true)),
-                                  Token(type: .and, lexeme: "and", line: 1),
-                                  .literal(.boolean(false))),
-                         Token(type: .or, lexeme: "or", line: 1),
-                         .literal(.boolean(true))))
+                .logical(
+                    .logical(
+                        .literal(
+                            Token(type: .true, lexeme: "true", line: 1),
+                            .boolean(true)),
+                        Token(type: .and, lexeme: "and", line: 1),
+                        .literal(
+                            Token(type: .false, lexeme: "false", line: 1),
+                            .boolean(false))),
+                    Token(type: .or, lexeme: "or", line: 1),
+                    .literal(
+                        Token(type: .true, lexeme: "true", line: 1),
+                        .boolean(true))))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -318,7 +365,9 @@ final class ParserTests: XCTestCase {
             .expression(
                 .assignment(
                     Token(type: .identifier, lexeme: "theAnswer", line: 1),
-                    .literal(.int(42)),
+                    .literal(
+                        Token(type: .int, lexeme: "42", line: 1),
+                        .int(42)),
                     UnresolvedDepth()))
         ]
         XCTAssertEqual(actual, expected)
@@ -345,7 +394,9 @@ final class ParserTests: XCTestCase {
                             Token(type: .identifier, lexeme: "foo", line: 1),
                             UnresolvedDepth()),
                         Token(type: .plus, lexeme: "+", line: 1),
-                        .literal(.int(42))),
+                        .literal(
+                            Token(type: .int, lexeme: "42", line: 1),
+                            .int(42))),
                     UnresolvedDepth()))
         ]
         XCTAssertEqual(actual, expected)
@@ -376,12 +427,18 @@ final class ParserTests: XCTestCase {
                 .binary(
                     .grouping(.unary(
                         Token(type: .minus, lexeme: "-", line: 1),
-                        .literal(.int(2)))),
+                        .literal(
+                            Token(type: .int, lexeme: "2", line: 1),
+                            .int(2)))),
                     Token(type: .star, lexeme: "*", line: 1),
                     .grouping(.binary(
-                        .literal(.int(3)),
+                        .literal(
+                            Token(type: .int, lexeme: "3", line: 1),
+                            .int(3)),
                         Token(type: .plus, lexeme: "+", line: 1),
-                        .literal(.int(4))))))
+                        .literal(
+                            Token(type: .int, lexeme: "4", line: 1),
+                            .int(4))))))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -425,13 +482,17 @@ final class ParserTests: XCTestCase {
             .for(
                 .variableDeclaration(
                     Token(type: .identifier, lexeme: "i", line: 1),
-                    .literal(.int(0))),
+                    .literal(
+                        Token(type: .int, lexeme: "0", line: 1),
+                        .int(0))),
                 .binary(
                     .variable(
                         Token(type: .identifier, lexeme: "i", line: 1),
                         UnresolvedDepth()),
                     Token(type: .less, lexeme: "<", line: 1),
-                    .literal(.int(5))),
+                    .literal(
+                        Token(type: .int, lexeme: "5", line: 1),
+                        .int(5))),
                 .assignment(
                     Token(type: .identifier, lexeme: "i", line: 1),
                     .binary(
@@ -439,7 +500,9 @@ final class ParserTests: XCTestCase {
                             Token(type: .identifier, lexeme: "i", line: 1),
                             UnresolvedDepth()),
                         Token(type: .plus, lexeme: "+", line: 1),
-                        .literal(.int(1))),
+                        .literal(
+                            Token(type: .int, lexeme: "1", line: 1),
+                            .int(1))),
                     UnresolvedDepth()),
                 .print(
                     .variable(
@@ -471,7 +534,9 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .for(
                 nil,
-                .literal(.boolean(true)),
+                .literal(
+                    Token(type: .true, lexeme: "true", line: 0),
+                    .boolean(true)),
                 nil,
                 .print(
                     .variable(
@@ -538,7 +603,9 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .if(
-                .literal(.boolean(true)),
+                .literal(
+                    Token(type: .true, lexeme: "true", line: 1),
+                    .boolean(true)),
                 .print(.string(Token(type: .string, lexeme: "\"Hello!\"", line: 2))),
                 nil)
         ]
@@ -574,7 +641,9 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .if(
-                .literal(.boolean(true)),
+                .literal(
+                    Token(type: .true, lexeme: "true", line: 1),
+                    .boolean(true)),
                 .print(.string(Token(type: .string, lexeme: "\"Hello!\"", line: 2))),
                 .print(.string(Token(type: .string, lexeme: "\"Goodbye\"", line: 4))))
         ]
@@ -654,7 +723,9 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .variableDeclaration(
                 Token(type: .identifier, lexeme: "theAnswer", line: 1),
-                .literal(.int(42)))
+                .literal(
+                    Token(type: .int, lexeme: "42", line: 1),
+                    .int(42)))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -708,10 +779,14 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .variableDeclaration(
                 Token(type: .identifier, lexeme: "the", line: 1),
-                .literal(.int(2))),
+                .literal(
+                    Token(type: .int, lexeme: "2", line: 1),
+                    .int(2))),
             .variableDeclaration(
                 Token(type: .identifier, lexeme: "answer", line: 2),
-                .literal(.int(21))),
+                .literal(
+                    Token(type: .int, lexeme: "21", line: 2),
+                    .int(21))),
             .print(
                 .binary(
                     .variable(
@@ -755,7 +830,9 @@ final class ParserTests: XCTestCase {
             .block([
                 .variableDeclaration(
                     Token(type: .identifier, lexeme: "theAnswer", line: 2),
-                    .literal(.int(42))),
+                    .literal(
+                        Token(type: .int, lexeme: "42", line: 2),
+                        .int(42))),
                 .print(
                     .variable(
                         Token(type: .identifier, lexeme: "theAnswer", line: 3),
@@ -829,7 +906,9 @@ final class ParserTests: XCTestCase {
                         Token(type: .identifier, lexeme: "x", line: 1),
                         UnresolvedDepth()),
                     Token(type: .lessEqual, lexeme: "<=", line: 1),
-                    .literal(.int(5))),
+                    .literal(
+                        Token(type: .int, lexeme: "5", line: 1),
+                        .int(5))),
                 .block([
                     .print(
                         .variable(
@@ -843,7 +922,9 @@ final class ParserTests: XCTestCase {
                                     Token(type: .identifier, lexeme: "x", line: 3),
                                     UnresolvedDepth()),
                                 Token(type: .plus, lexeme: "+", line: 3),
-                                .literal(.int(1))),
+                                .literal(
+                                    Token(type: .int, lexeme: "1", line: 3),
+                                    .int(1))),
                             UnresolvedDepth())),
                 ]))
         ]
@@ -901,7 +982,10 @@ final class ParserTests: XCTestCase {
                     Token(type: .identifier, lexeme: "theAnswer", line: 1),
                     ParameterList(normalParameters: []),
                     [
-                        .print(.literal(.int(42)))
+                        .print(
+                            .literal(
+                                Token(type: .int, lexeme: "42", line: 2),
+                                .int(42)))
                     ])),
         ]
         XCTAssertEqual(actual, expected)
@@ -1095,8 +1179,12 @@ final class ParserTests: XCTestCase {
                         UnresolvedDepth()),
                     Token(type: .rightParen, lexeme: ")", line: 1),
                     [
-                        .literal(.int(1)),
-                        .literal(.int(2)),
+                        .literal(
+                            Token(type: .int, lexeme: "1", line: 1),
+                            .int(1)),
+                        .literal(
+                            Token(type: .int, lexeme: "2", line: 1),
+                            .int(2)),
                     ]))
         ]
         XCTAssertEqual(actual, expected)
@@ -1132,9 +1220,15 @@ final class ParserTests: XCTestCase {
                         .splat(
                             Token(type: .star, lexeme: "*", line: 1),
                             .list([
-                                .literal(.int(1)),
-                                .literal(.int(2)),
-                                .literal(.int(3)),
+                                .literal(
+                                    Token(type: .int, lexeme: "1", line: 1),
+                                    .int(1)),
+                                .literal(
+                                    Token(type: .int, lexeme: "2", line: 1),
+                                    .int(2)),
+                                .literal(
+                                    Token(type: .int, lexeme: "3", line: 1),
+                                    .int(3)),
                             ])),
                     ])),
         ]
@@ -1478,7 +1572,9 @@ final class ParserTests: XCTestCase {
                                     Token(type: .return, lexeme: "return", line: 3),
                                     .binary(
                                         .binary(
-                                            .literal(.double(3.14159)),
+                                            .literal(
+                                                Token(type: .double, lexeme: "3.14159", line: 3),
+                                                .double(3.14159)),
                                             Token(type: .star, lexeme: "*", line: 3),
                                             .get(
                                                 Token(type: .dot, lexeme: ".", line: 3),
@@ -1518,9 +1614,13 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .list([
-                    .literal(.int(1)),
+                    .literal(
+                        Token(type: .int, lexeme: "1", line: 1),
+                        .int(1)),
                     .string(Token(type: .string, lexeme: "\"one\"", line: 1)),
-                    .literal(.boolean(true))
+                    .literal(
+                        Token(type: .true, lexeme: "true", line: 1),
+                        .boolean(true))
                 ]))
         ]
         XCTAssertEqual(actual, expected)
@@ -1598,7 +1698,7 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .dictionary([
-                    (.string(Token(type: .string, lexeme: "\"a\"", line: 1)), .literal(.int(1))),
+                    (.string(Token(type: .string, lexeme: "\"a\"", line: 1)), .literal(Token(type: .int, lexeme: "1", line: 1),.int(1))),
                 ]))
         ]
         XCTAssertEqual(actual, expected)
@@ -1628,9 +1728,9 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .dictionary([
-                    (.string(Token(type: .string, lexeme: "\"a\"", line: 1)), .literal(.int(1))),
-                    (.string(Token(type: .string, lexeme: "\"b\"", line: 1)), .literal(.int(2))),
-                    (.string(Token(type: .string, lexeme: "\"c\"", line: 1)), .literal(.int(3))),
+                    (.string(Token(type: .string, lexeme: "\"a\"", line: 1)), .literal(Token(type: .int, lexeme: "1", line: 1),.int(1))),
+                    (.string(Token(type: .string, lexeme: "\"b\"", line: 1)), .literal(Token(type: .int, lexeme: "2", line: 1),.int(2))),
+                    (.string(Token(type: .string, lexeme: "\"c\"", line: 1)), .literal(Token(type: .int, lexeme: "3", line: 1),.int(3))),
                 ]))
         ]
         XCTAssertEqual(actual, expected)
@@ -1724,12 +1824,16 @@ final class ParserTests: XCTestCase {
                                     .block([
                                         .return(
                                             Token(type: .return, lexeme: "return", line: 5),
-                                            .literal(.boolean(true))),
+                                            .literal(
+                                                Token(type: .true, lexeme: "true", line: 5),
+                                                .boolean(true))),
                                     ]),
                                     nil),
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 7),
-                                    .literal(.boolean(false)))
+                                    .literal(
+                                        Token(type: .false, lexeme: "false", line: 7),
+                                        .boolean(false)))
                             ]))
                 ],
                 []),
@@ -1806,7 +1910,9 @@ final class ParserTests: XCTestCase {
                     SwitchCaseDeclaration(
                         caseToken: Token(type: .case, lexeme: "case", line: 2),
                         valueExpressions: [
-                            .literal(.int(1))
+                            .literal(
+                                Token(type: .int, lexeme: "1", line: 2),
+                                .int(1))
                         ],
                         statement: .block([
                             .print(.string(Token(type: .string, lexeme: "\"one\"", line: 3)))
@@ -1814,9 +1920,15 @@ final class ParserTests: XCTestCase {
                     SwitchCaseDeclaration(
                         caseToken: Token(type: .case, lexeme: "case", line: 4),
                         valueExpressions: [
-                            .literal(.int(2)),
-                            .literal(.int(3)),
-                            .literal(.int(4)),
+                            .literal(
+                                Token(type: .int, lexeme: "2", line: 4),
+                                .int(2)),
+                            .literal(
+                                Token(type: .int, lexeme: "3", line: 4),
+                                .int(3)),
+                            .literal(
+                                Token(type: .int, lexeme: "4", line: 4),
+                                .int(4)),
                         ],
                         statement: .block([
                             .print(.string(Token(type: .string, lexeme: "\"two\"", line: 5))),

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -485,6 +485,7 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .for(
+                Token(type: .for, lexeme: "for", line: 1),
                 .variableDeclaration(
                     Token(type: .identifier, lexeme: "i", line: 1),
                     .literal(
@@ -539,6 +540,7 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .for(
+                Token(type: .for, lexeme: "for", line: 1),
                 nil,
                 .literal(
                     Token(type: .true, lexeme: "true", line: 0),

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -91,6 +91,7 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .grouping(
+                    Token(type: .leftParen, lexeme: "(", line: 1),
                     .literal(
                         Token(type: .int, lexeme: "42", line: 1),
                         .int(42))))
@@ -425,20 +426,24 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .binary(
-                    .grouping(.unary(
-                        Token(type: .minus, lexeme: "-", line: 1),
-                        .literal(
-                            Token(type: .int, lexeme: "2", line: 1),
-                            .int(2)))),
+                    .grouping(
+                        Token(type: .leftParen, lexeme: "(", line: 1),
+                        .unary(
+                            Token(type: .minus, lexeme: "-", line: 1),
+                            .literal(
+                                Token(type: .int, lexeme: "2", line: 1),
+                                .int(2)))),
                     Token(type: .star, lexeme: "*", line: 1),
-                    .grouping(.binary(
-                        .literal(
-                            Token(type: .int, lexeme: "3", line: 1),
-                            .int(3)),
-                        Token(type: .plus, lexeme: "+", line: 1),
-                        .literal(
-                            Token(type: .int, lexeme: "4", line: 1),
-                            .int(4))))))
+                    .grouping(
+                        Token(type: .leftParen, lexeme: "(", line: 1),
+                        .binary(
+                            .literal(
+                                Token(type: .int, lexeme: "3", line: 1),
+                                .int(3)),
+                            Token(type: .plus, lexeme: "+", line: 1),
+                            .literal(
+                                Token(type: .int, lexeme: "4", line: 1),
+                                .int(4))))))
         ]
         XCTAssertEqual(actual, expected)
     }

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -1230,6 +1230,7 @@ final class ParserTests: XCTestCase {
                             [
                                 .print(
                                     .get(
+                                        Token(type: .dot, lexeme: ".", line: 3),
                                         .this(
                                             Token(type: .this, lexeme: "this", line: 3),
                                             UnresolvedDepth()),
@@ -1256,6 +1257,7 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .get(
+                    Token(type: .dot, lexeme: ".", line: 1),
                     .variable(
                         Token(type: .identifier, lexeme: "person", line: 1),
                         UnresolvedDepth()),
@@ -1281,6 +1283,7 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .set(
+                    Token(type: .dot, lexeme: ".", line: 1),
                     .variable(
                         Token(type: .identifier, lexeme: "person", line: 1),
                         UnresolvedDepth()),
@@ -1478,12 +1481,14 @@ final class ParserTests: XCTestCase {
                                             .literal(.double(3.14159)),
                                             Token(type: .star, lexeme: "*", line: 3),
                                             .get(
+                                                Token(type: .dot, lexeme: ".", line: 3),
                                                 .this(
                                                     Token(type: .this, lexeme: "this", line: 3),
                                                     UnresolvedDepth()),
                                                 Token(type: .identifier, lexeme: "radius", line: 3))),
                                         Token(type: .star, lexeme: "*", line: 3),
                                         .get(
+                                            Token(type: .dot, lexeme: ".", line: 3),
                                             .this(
                                                 Token(type: .this, lexeme: "this", line: 3),
                                                 UnresolvedDepth()),
@@ -1711,6 +1716,7 @@ final class ParserTests: XCTestCase {
                                             UnresolvedDepth()),
                                         Token(type: .equalEqual, lexeme: "==", line: 4),
                                         .get(
+                                            Token(type: .dot, lexeme: ".", line: 4),
                                             .variable(
                                                 Token(type: .identifier, lexeme: "Foo", line: 4),
                                                 UnresolvedDepth()),

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -510,6 +510,7 @@ final class ParserTests: XCTestCase {
                             .int(1))),
                     UnresolvedDepth()),
                 .print(
+                    Token(type: .print, lexeme: "print", line: 2),
                     .variable(
                         Token(type: .identifier, lexeme: "i", line: 2),
                         UnresolvedDepth()))),
@@ -544,6 +545,7 @@ final class ParserTests: XCTestCase {
                     .boolean(true)),
                 nil,
                 .print(
+                    Token(type: .print, lexeme: "print", line: 2),
                     .variable(
                         Token(type: .identifier, lexeme: "i", line: 2),
                         UnresolvedDepth())))
@@ -612,7 +614,9 @@ final class ParserTests: XCTestCase {
                 .literal(
                     Token(type: .true, lexeme: "true", line: 1),
                     .boolean(true)),
-                .print(.string(Token(type: .string, lexeme: "\"Hello!\"", line: 2))),
+                .print(
+                    Token(type: .print, lexeme: "print", line: 2),
+                    .string(Token(type: .string, lexeme: "\"Hello!\"", line: 2))),
                 nil)
         ]
         XCTAssertEqual(actual, expected)
@@ -651,8 +655,12 @@ final class ParserTests: XCTestCase {
                 .literal(
                     Token(type: .true, lexeme: "true", line: 1),
                     .boolean(true)),
-                .print(.string(Token(type: .string, lexeme: "\"Hello!\"", line: 2))),
-                .print(.string(Token(type: .string, lexeme: "\"Goodbye\"", line: 4))))
+                .print(
+                    Token(type: .print, lexeme: "print", line: 2),
+                    .string(Token(type: .string, lexeme: "\"Hello!\"", line: 2))),
+                .print(
+                    Token(type: .print, lexeme: "print", line: 4),
+                    .string(Token(type: .string, lexeme: "\"Goodbye\"", line: 4))))
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -692,6 +700,7 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .print(
+                Token(type: .print, lexeme: "print", line: 1),
                 .string(Token(type: .string, lexeme: "\"forty-two\"", line: 1)))
         ]
         XCTAssertEqual(actual, expected)
@@ -795,6 +804,7 @@ final class ParserTests: XCTestCase {
                     Token(type: .int, lexeme: "21", line: 2),
                     .int(21))),
             .print(
+                Token(type: .print, lexeme: "print", line: 3),
                 .binary(
                     .variable(
                         Token(type: .identifier, lexeme: "the", line: 3),
@@ -841,6 +851,7 @@ final class ParserTests: XCTestCase {
                         Token(type: .int, lexeme: "42", line: 2),
                         .int(42))),
                 .print(
+                    Token(type: .print, lexeme: "print", line: 3),
                     .variable(
                         Token(type: .identifier, lexeme: "theAnswer", line: 3),
                         UnresolvedDepth())),
@@ -918,6 +929,7 @@ final class ParserTests: XCTestCase {
                         .int(5))),
                 .block([
                     .print(
+                        Token(type: .print, lexeme: "print", line: 2),
                         .variable(
                             Token(type: .identifier, lexeme: "x", line: 2),
                             UnresolvedDepth())),
@@ -990,6 +1002,7 @@ final class ParserTests: XCTestCase {
                     ParameterList(normalParameters: []),
                     [
                         .print(
+                            Token(type: .print, lexeme: "print", line: 2),
                             .literal(
                                 Token(type: .int, lexeme: "42", line: 2),
                                 .int(42)))
@@ -1332,6 +1345,7 @@ final class ParserTests: XCTestCase {
                             ParameterList(normalParameters: []),
                             [
                                 .print(
+                                    Token(type: .print, lexeme: "print", line: 3),
                                     .get(
                                         Token(type: .dot, lexeme: ".", line: 3),
                                         .this(
@@ -1934,7 +1948,9 @@ final class ParserTests: XCTestCase {
                                 .int(1))
                         ],
                         statement: .block([
-                            .print(.string(Token(type: .string, lexeme: "\"one\"", line: 3)))
+                            .print(
+                                Token(type: .print, lexeme: "print", line: 3),
+                                .string(Token(type: .string, lexeme: "\"one\"", line: 3)))
                         ])),
                     SwitchCaseDeclaration(
                         caseToken: Token(type: .case, lexeme: "case", line: 4),
@@ -1950,14 +1966,22 @@ final class ParserTests: XCTestCase {
                                 .int(4)),
                         ],
                         statement: .block([
-                            .print(.string(Token(type: .string, lexeme: "\"two\"", line: 5))),
-                            .print(.string(Token(type: .string, lexeme: "\"three\"", line: 6))),
-                            .print(.string(Token(type: .string, lexeme: "\"or four\"", line: 7)))
+                            .print(
+                                Token(type: .print, lexeme: "print", line: 5),
+                                .string(Token(type: .string, lexeme: "\"two\"", line: 5))),
+                            .print(
+                                Token(type: .print, lexeme: "print", line: 6),
+                                .string(Token(type: .string, lexeme: "\"three\"", line: 6))),
+                            .print(
+                                Token(type: .print, lexeme: "print", line: 7),
+                                .string(Token(type: .string, lexeme: "\"or four\"", line: 7)))
                         ])),
                     SwitchCaseDeclaration(
                         caseToken: Token(type: .default, lexeme: "default", line: 8),
                         statement: .block([
-                            .print(.string(Token(type: .string, lexeme: "\"unhandled\"", line: 9))),
+                            .print(
+                                Token(type: .print, lexeme: "print", line: 9),
+                                .string(Token(type: .string, lexeme: "\"unhandled\"", line: 9))),
                         ])),
                 ])
         ]

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -898,6 +898,7 @@ final class ParserTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "theAnswer", line: 1),
                 .lambda(
+                    Token(type: .identifier, lexeme: "theAnswer", line: 1),
                     ParameterList(normalParameters: []),
                     [
                         .print(.literal(.int(42)))
@@ -936,6 +937,7 @@ final class ParserTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "add", line: 1),
                 .lambda(
+                    Token(type: .identifier, lexeme: "add", line: 1),
                     ParameterList(normalParameters: [
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
@@ -986,6 +988,7 @@ final class ParserTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "foo", line: 1),
                 .lambda(
+                    Token(type: .identifier, lexeme: "foo", line: 1),
                     ParameterList(
                         normalParameters: [
                             Token(type: .identifier, lexeme: "a", line: 1),
@@ -1127,6 +1130,7 @@ final class ParserTests: XCTestCase {
                     Token(type: .rightParen, lexeme: ")", line: 1),
                     [
                         .splat(
+                            Token(type: .star, lexeme: "*", line: 1),
                             .list([
                                 .literal(.int(1)),
                                 .literal(.int(2)),
@@ -1162,6 +1166,7 @@ final class ParserTests: XCTestCase {
         let expected: [Statement<UnresolvedDepth>] = [
             .expression(
                 .lambda(
+                    Token(type: .fun, lexeme: "fun", line: 1),
                     ParameterList(normalParameters: [
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
@@ -1220,6 +1225,7 @@ final class ParserTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "sayName", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "sayName", line: 2),
                             ParameterList(normalParameters: []),
                             [
                                 .print(
@@ -1327,6 +1333,7 @@ final class ParserTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "add", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "add", line: 2),
                             ParameterList(normalParameters: [
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
@@ -1394,6 +1401,7 @@ final class ParserTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "someMethod", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "someMethod", line: 2),
                             ParameterList(normalParameters: [
                                 Token(type: .identifier, lexeme: "arg", line: 2)
                             ]),
@@ -1460,6 +1468,7 @@ final class ParserTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "area", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "area", line: 2),
                             nil,
                             [
                                 .return(
@@ -1690,6 +1699,7 @@ final class ParserTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "isBar", line: 3),
                         .lambda(
+                            Token(type: .identifier, lexeme: "isBar", line: 3),
                             ParameterList(
                                 normalParameters: [],
                                 variadicParameter: nil),
@@ -1782,11 +1792,13 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .switch(
+                Token(type: .switch, lexeme: "switch", line: 1),
                 .variable(
                     Token(type: .identifier, lexeme: "foo", line: 1),
                     UnresolvedDepth()),
                 [
                     SwitchCaseDeclaration(
+                        caseToken: Token(type: .case, lexeme: "case", line: 2),
                         valueExpressions: [
                             .literal(.int(1))
                         ],
@@ -1794,6 +1806,7 @@ final class ParserTests: XCTestCase {
                             .print(.string(Token(type: .string, lexeme: "\"one\"", line: 3)))
                         ])),
                     SwitchCaseDeclaration(
+                        caseToken: Token(type: .case, lexeme: "case", line: 4),
                         valueExpressions: [
                             .literal(.int(2)),
                             .literal(.int(3)),
@@ -1805,6 +1818,7 @@ final class ParserTests: XCTestCase {
                             .print(.string(Token(type: .string, lexeme: "\"or four\"", line: 7)))
                         ])),
                     SwitchCaseDeclaration(
+                        caseToken: Token(type: .default, lexeme: "default", line: 8),
                         statement: .block([
                             .print(.string(Token(type: .string, lexeme: "\"unhandled\"", line: 9))),
                         ])),

--- a/sloxTests/ParserTests.swift
+++ b/sloxTests/ParserTests.swift
@@ -608,6 +608,7 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .if(
+                Token(type: .if, lexeme: "if", line: 1),
                 .literal(
                     Token(type: .true, lexeme: "true", line: 1),
                     .boolean(true)),
@@ -646,6 +647,7 @@ final class ParserTests: XCTestCase {
         let actual = try parser.parse()
         let expected: [Statement<UnresolvedDepth>] = [
             .if(
+                Token(type: .if, lexeme: "if", line: 1),
                 .literal(
                     Token(type: .true, lexeme: "true", line: 1),
                     .boolean(true)),
@@ -1826,6 +1828,7 @@ final class ParserTests: XCTestCase {
                                 variadicParameter: nil),
                             [
                                 .if(
+                                    Token(type: .if, lexeme: "if", line: 4),
                                     .binary(
                                         .this(
                                             Token(type: .this, lexeme: "this", line: 4),

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -588,17 +588,19 @@ final class ResolverTests: XCTestCase {
             .expression(
                 .splat(
                     Token(type: .star, lexeme: "*", line: 1),
-                    .list([
-                        .literal(
-                            Token(type: .int, lexeme: "1", line: 1),
-                            .int(1)),
-                        .literal(
-                            Token(type: .int, lexeme: "2", line: 1),
-                            .int(2)),
-                        .literal(
-                            Token(type: .int, lexeme: "3", line: 1),
-                            .int(3)),
-                    ])))
+                    .list(
+                        Token(type: .leftBracket, lexeme: "[", line: 1),
+                        [
+                            .literal(
+                                Token(type: .int, lexeme: "1", line: 1),
+                                .int(1)),
+                            .literal(
+                                Token(type: .int, lexeme: "2", line: 1),
+                                .int(2)),
+                            .literal(
+                                Token(type: .int, lexeme: "3", line: 1),
+                                .int(3)),
+                        ])))
         ]
 
         var resolver = Resolver()

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -63,18 +63,20 @@ final class ResolverTests: XCTestCase {
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
                     ]),
-                    .block([
-                        .return(
-                            Token(type: .return, lexeme: "return", line: 2),
-                            .binary(
-                                .variable(
-                                    Token(type: .identifier, lexeme: "a", line: 2),
-                                    UnresolvedDepth()),
-                                Token(type: .plus, lexeme: "+", line: 2),
-                                .variable(
-                                    Token(type: .identifier, lexeme: "b", line: 2),
-                                    UnresolvedDepth()))),
-                    ]))),
+                    .block(
+                        Token(type: .leftBrace, lexeme: "{", line: 1),
+                        [
+                            .return(
+                                Token(type: .return, lexeme: "return", line: 2),
+                                .binary(
+                                    .variable(
+                                        Token(type: .identifier, lexeme: "a", line: 2),
+                                        UnresolvedDepth()),
+                                    Token(type: .plus, lexeme: "+", line: 2),
+                                    .variable(
+                                        Token(type: .identifier, lexeme: "b", line: 2),
+                                        UnresolvedDepth()))),
+                        ]))),
         ]
 
         var resolver = Resolver()
@@ -88,18 +90,20 @@ final class ResolverTests: XCTestCase {
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
                     ]),
-                    .block([
-                        .return(
-                            Token(type: .return, lexeme: "return", line: 2),
-                            .binary(
-                                .variable(
-                                    Token(type: .identifier, lexeme: "a", line: 2),
-                                    1),
-                                Token(type: .plus, lexeme: "+", line: 2),
-                                .variable(
-                                    Token(type: .identifier, lexeme: "b", line: 2),
-                                    1))),
-                    ]))),
+                    .block(
+                        Token(type: .leftBrace, lexeme: "{", line: 1),
+                        [
+                            .return(
+                                Token(type: .return, lexeme: "return", line: 2),
+                                .binary(
+                                    .variable(
+                                        Token(type: .identifier, lexeme: "a", line: 2),
+                                        1),
+                                    Token(type: .plus, lexeme: "+", line: 2),
+                                    .variable(
+                                        Token(type: .identifier, lexeme: "b", line: 2),
+                                        1))),
+                        ]))),
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -114,13 +118,15 @@ final class ResolverTests: XCTestCase {
                 .lambda(
                     Token(type: .identifier, lexeme: "answer", line: 1),
                     nil,
-                    .block([
-                        .return(
-                            Token(type: .return, lexeme: "return", line: 2),
-                            .literal(
-                                Token(type: .int, lexeme: "42", line: 2),
-                                .int(42)))
-                    ]))),
+                    .block(
+                        Token(type: .leftBrace, lexeme: "{", line: 1),
+                        [
+                            .return(
+                                Token(type: .return, lexeme: "return", line: 2),
+                                .literal(
+                                    Token(type: .int, lexeme: "42", line: 2),
+                                    .int(42)))
+                        ]))),
         ]
 
         var resolver = Resolver()
@@ -137,17 +143,23 @@ final class ResolverTests: XCTestCase {
             .variableDeclaration(
                 Token(type: .identifier, lexeme: "becca", line: 1),
                 nil),
-            .block([
-                .block([
-                    .block([
-                        .expression(
-                            .assignment(
-                                Token(type: .identifier, lexeme: "becca", line: 1),
-                                .string(Token(type: .string, lexeme: "\"answer\"", line: 1)),
-                                UnresolvedDepth()))
+            .block(
+                Token(type: .leftBrace, lexeme: "{", line: 1),
+                [
+                .block(
+                    Token(type: .leftBrace, lexeme: "{", line: 1),
+                    [
+                    .block(
+                        Token(type: .leftBrace, lexeme: "{", line: 1),
+                        [
+                            .expression(
+                                .assignment(
+                                    Token(type: .identifier, lexeme: "becca", line: 1),
+                                    .string(Token(type: .string, lexeme: "\"answer\"", line: 1)),
+                                    UnresolvedDepth()))
+                        ])
                     ])
                 ])
-            ])
         ]
 
         var resolver = Resolver()
@@ -156,17 +168,23 @@ final class ResolverTests: XCTestCase {
             .variableDeclaration(
                 Token(type: .identifier, lexeme: "becca", line: 1),
                 nil),
-            .block([
-                .block([
-                    .block([
-                        .expression(
-                            .assignment(
-                                Token(type: .identifier, lexeme: "becca", line: 1),
-                                .string(Token(type: .string, lexeme: "\"answer\"", line: 1)),
-                                3))
+            .block(
+                Token(type: .leftBrace, lexeme: "{", line: 1),
+                [
+                .block(
+                    Token(type: .leftBrace, lexeme: "{", line: 1),
+                    [
+                    .block(
+                        Token(type: .leftBrace, lexeme: "{", line: 1),
+                        [
+                            .expression(
+                                .assignment(
+                                    Token(type: .identifier, lexeme: "becca", line: 1),
+                                    .string(Token(type: .string, lexeme: "\"answer\"", line: 1)),
+                                    3))
+                        ])
                     ])
                 ])
-            ])
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -174,13 +192,15 @@ final class ResolverTests: XCTestCase {
     func testResolveReturnStatementOutsideFunctionBody() throws {
         // { return 42; }
         let statements: [Statement<UnresolvedDepth>] = [
-            .block([
-                .return(
-                    Token(type: .return, lexeme: "return", line: 1),
-                    .literal(
-                        Token(type: .int, lexeme: "42", line: 1),
-                        .int(42))),
-            ])
+            .block(
+                Token(type: .leftBrace, lexeme: "{", line: 1),
+                [
+                    .return(
+                        Token(type: .return, lexeme: "return", line: 1),
+                        .literal(
+                            Token(type: .int, lexeme: "42", line: 1),
+                            .int(42))),
+                ])
         ]
 
         var resolver = Resolver()
@@ -200,13 +220,15 @@ final class ResolverTests: XCTestCase {
             .variableDeclaration(
                 Token(type: .identifier, lexeme: "x", line: 1),
                 .string(Token(type: .string, lexeme: "\"outer\"", line: 1))),
-            .block([
-                .variableDeclaration(
-                    Token(type: .identifier, lexeme: "x", line: 3),
-                    .variable(
+            .block(
+                Token(type: .leftBrace, lexeme: "{", line: 2),
+                [
+                    .variableDeclaration(
                         Token(type: .identifier, lexeme: "x", line: 3),
-                        UnresolvedDepth())),
-            ])
+                        .variable(
+                            Token(type: .identifier, lexeme: "x", line: 3),
+                            UnresolvedDepth())),
+                ])
         ]
 
         var resolver = Resolver()
@@ -223,14 +245,16 @@ final class ResolverTests: XCTestCase {
         //     var a = "second";
         // }
         let statements: [Statement<UnresolvedDepth>] = [
-            .block([
-                .variableDeclaration(
-                    Token(type: .identifier, lexeme: "a", line: 2),
-                    .string(Token(type: .string, lexeme: "\"first\"", line: 1))),
-                .variableDeclaration(
-                    Token(type: .identifier, lexeme: "a", line: 3),
-                    .string(Token(type: .string, lexeme: "\"second\"", line: 1))),
-            ])
+            .block(
+                Token(type: .leftBrace, lexeme: "{", line: 1),
+                [
+                    .variableDeclaration(
+                        Token(type: .identifier, lexeme: "a", line: 2),
+                        .string(Token(type: .string, lexeme: "\"first\"", line: 1))),
+                    .variableDeclaration(
+                        Token(type: .identifier, lexeme: "a", line: 3),
+                        .string(Token(type: .string, lexeme: "\"second\"", line: 1))),
+                ])
         ]
 
         var resolver = Resolver()
@@ -257,16 +281,18 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "sayName", line: 2),
                             ParameterList(normalParameters: []),
-                            .block([
-                                .print(
-                                    Token(type: .print, lexeme: "print", line: 3),
-                                    .get(
-                                        Token(type: .dot, lexeme: ".", line: 3),
-                                        .this(
-                                            Token(type: .this, lexeme: "this", line: 3),
-                                            UnresolvedDepth()),
-                                        Token(type: .identifier, lexeme: "name", line: 3)))
-                            ])))
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .print(
+                                        Token(type: .print, lexeme: "print", line: 3),
+                                        .get(
+                                            Token(type: .dot, lexeme: ".", line: 3),
+                                            .this(
+                                                Token(type: .this, lexeme: "this", line: 3),
+                                                UnresolvedDepth()),
+                                            Token(type: .identifier, lexeme: "name", line: 3)))
+                                ])))
                 ],
                 [])
         ]
@@ -283,16 +309,18 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "sayName", line: 2),
                             ParameterList(normalParameters: []),
-                            .block([
-                                .print(
-                                    Token(type: .print, lexeme: "print", line: 3),
-                                    .get(
-                                        Token(type: .dot, lexeme: ".", line: 3),
-                                        .this(
-                                            Token(type: .this, lexeme: "this", line: 3),
-                                            2),
-                                        Token(type: .identifier, lexeme: "name", line: 3)))
-                            ])))
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .print(
+                                        Token(type: .print, lexeme: "print", line: 3),
+                                        .get(
+                                            Token(type: .dot, lexeme: ".", line: 3),
+                                            .this(
+                                                Token(type: .this, lexeme: "this", line: 3),
+                                                2),
+                                            Token(type: .identifier, lexeme: "name", line: 3)))
+                                ])))
                 ],
                 [])
         ]
@@ -309,13 +337,15 @@ final class ResolverTests: XCTestCase {
                 .lambda(
                     Token(type: .identifier, lexeme: "foo", line: 1),
                     ParameterList(normalParameters: []),
-                    .block([
-                        .return(
-                            Token(type: .return, lexeme: "return", line: 2),
-                            .this(
-                                Token(type: .this, lexeme: "this", line: 2),
-                                UnresolvedDepth()))
-                    ]))),
+                    .block(
+                        Token(type: .leftBrace, lexeme: "{", line: 1),
+                        [
+                            .return(
+                                Token(type: .return, lexeme: "return", line: 2),
+                                .this(
+                                    Token(type: .this, lexeme: "this", line: 2),
+                                    UnresolvedDepth()))
+                        ]))),
         ]
 
         var resolver = Resolver()
@@ -342,13 +372,15 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "init", line: 2),
                             ParameterList(normalParameters: []),
-                            .block([
-                                .return(
-                                    Token(type: .return, lexeme: "return", line: 3),
-                                    .literal(
-                                        Token(type: .int, lexeme: "42", line: 3),
-                                        .int(42)))
-                            ])))
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .return(
+                                        Token(type: .return, lexeme: "return", line: 3),
+                                        .literal(
+                                            Token(type: .int, lexeme: "42", line: 3),
+                                            .int(42)))
+                                ])))
                 ],
                 [])
         ]
@@ -381,18 +413,20 @@ final class ResolverTests: XCTestCase {
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
                             ]),
-                            .block([
-                                .return(
-                                    Token(type: .return, lexeme: "return", line: 3),
-                                    .binary(
-                                        .variable(
-                                            Token(type: .identifier, lexeme: "a", line: 3),
-                                            UnresolvedDepth()),
-                                        Token(type: .plus, lexeme: "+", line: 3),
-                                        .variable(
-                                            Token(type: .identifier, lexeme: "b", line: 3),
-                                            UnresolvedDepth())))
-                            ])))
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .return(
+                                        Token(type: .return, lexeme: "return", line: 3),
+                                        .binary(
+                                            .variable(
+                                                Token(type: .identifier, lexeme: "a", line: 3),
+                                                UnresolvedDepth()),
+                                            Token(type: .plus, lexeme: "+", line: 3),
+                                            .variable(
+                                                Token(type: .identifier, lexeme: "b", line: 3),
+                                                UnresolvedDepth())))
+                                ])))
                 ])
         ]
 
@@ -412,18 +446,20 @@ final class ResolverTests: XCTestCase {
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
                             ]),
-                            .block([
-                                .return(
-                                    Token(type: .return, lexeme: "return", line: 3),
-                                    .binary(
-                                        .variable(
-                                            Token(type: .identifier, lexeme: "a", line: 3),
-                                            1),
-                                        Token(type: .plus, lexeme: "+", line: 3),
-                                        .variable(
-                                            Token(type: .identifier, lexeme: "b", line: 3),
-                                            1)))
-                            ])))
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .return(
+                                        Token(type: .return, lexeme: "return", line: 3),
+                                        .binary(
+                                            .variable(
+                                                Token(type: .identifier, lexeme: "a", line: 3),
+                                                1),
+                                            Token(type: .plus, lexeme: "+", line: 3),
+                                            .variable(
+                                                Token(type: .identifier, lexeme: "b", line: 3),
+                                                1)))
+                                ])))
                 ])
         ]
         XCTAssertEqual(actual, expected)
@@ -446,16 +482,18 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "init", line: 2),
                             ParameterList(normalParameters: []),
-                            .block([
-                                .expression(
-                                    .set(
-                                        Token(type: .dot, lexeme: ".", line: 3),
-                                        .this(
-                                            Token(type: .this, lexeme: "this", line: 3),
-                                            UnresolvedDepth()),
-                                        Token(type: .identifier, lexeme: "name", line: 3),
-                                        .string(Token(type: .string, lexeme: "\"bad\"", line: 1))))
-                            ])))
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .expression(
+                                        .set(
+                                            Token(type: .dot, lexeme: ".", line: 3),
+                                            .this(
+                                                Token(type: .this, lexeme: "this", line: 3),
+                                                UnresolvedDepth()),
+                                            Token(type: .identifier, lexeme: "name", line: 3),
+                                            .string(Token(type: .string, lexeme: "\"bad\"", line: 1))))
+                                ])))
                 ])
         ]
 
@@ -501,17 +539,19 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "someMethod", line: 2),
                             ParameterList(normalParameters: []),
-                            .block([
-                                .expression(
-                                    .call(
-                                        .super(
-                                            Token(type: .super, lexeme: "super", line: 3),
-                                            Token(type: .identifier, lexeme: "someMethod", line: 3),
-                                            UnresolvedDepth()),
-                                        Token(type: .rightParen, lexeme: ")", line: 3),
-                                        [])
-                                )
-                            ])))
+                            .block(
+                                Token(type: .leftBrace, lexeme: "{", line: 2),
+                                [
+                                    .expression(
+                                        .call(
+                                            .super(
+                                                Token(type: .super, lexeme: "super", line: 3),
+                                                Token(type: .identifier, lexeme: "someMethod", line: 3),
+                                                UnresolvedDepth()),
+                                            Token(type: .rightParen, lexeme: ")", line: 3),
+                                            [])
+                                    )
+                                ])))
                 ],
                 [])
         ]
@@ -558,23 +598,27 @@ final class ResolverTests: XCTestCase {
                 .literal(
                     Token(type: .true, lexeme: "true", line: 1),
                     .boolean(true)),
-                .block([
-                    .function(
-                        Token(type: .identifier, lexeme: "foo", line: 2),
-                        .lambda(
+                .block(
+                    Token(type: .leftBrace, lexeme: "{", line: 1),
+                    [
+                        .function(
                             Token(type: .identifier, lexeme: "foo", line: 2),
-                            ParameterList(normalParameters: []),
-                            .block([
-                                .break(Token(type: .break, lexeme: "break", line: 3))
-                            ]))),
-                    .expression(
-                        .call(
-                            .variable(
-                                Token(type: .identifier, lexeme: "foo", line: 5),
-                                UnresolvedDepth()),
-                            Token(type: .rightParen, lexeme: ")", line: 5),
-                            []))
-                ]))
+                            .lambda(
+                                Token(type: .identifier, lexeme: "foo", line: 2),
+                                ParameterList(normalParameters: []),
+                                .block(
+                                    Token(type: .leftBrace, lexeme: "{", line: 2),
+                                    [
+                                        .break(Token(type: .break, lexeme: "break", line: 3))
+                                    ]))),
+                        .expression(
+                            .call(
+                                .variable(
+                                    Token(type: .identifier, lexeme: "foo", line: 5),
+                                    UnresolvedDepth()),
+                                Token(type: .rightParen, lexeme: ")", line: 5),
+                                []))
+                    ]))
         ]
 
         var resolver = Resolver()
@@ -683,7 +727,9 @@ final class ResolverTests: XCTestCase {
                                 Token(type: .int, lexeme: "42", line: 2),
                                 .int(42))
                         ],
-                        statement: .block([]))
+                        statement: .block(
+                            Token(type: .colon, lexeme: ":", line: 2),
+                            []))
                 ])
         ]
 

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -9,10 +9,11 @@ import XCTest
 
 final class ResolverTests: XCTestCase {
     func testResolveLiteralExpression() throws {
-        // "forty-two"
+        // 42
         let statements: [Statement<UnresolvedDepth>] = [
             .expression(
                 .literal(
+                    Token(type: .int, lexeme: "42", line: 1),
                     .int(42))),
         ]
 
@@ -21,6 +22,7 @@ final class ResolverTests: XCTestCase {
         let expected: [Statement<Int>] = [
             .expression(
                 .literal(
+                    Token(type: .int, lexeme: "42", line: 1),
                     .int(42))),
         ]
         XCTAssertEqual(actual, expected)
@@ -31,7 +33,9 @@ final class ResolverTests: XCTestCase {
         let statements: [Statement<UnresolvedDepth>] = [
             .variableDeclaration(
                 Token(type: .identifier, lexeme: "answer", line: 1),
-                .literal(.int(42))),
+                .literal(
+                    Token(type: .int, lexeme: "42", line: 1),
+                    .int(42))),
         ]
 
         var resolver = Resolver()
@@ -39,7 +43,9 @@ final class ResolverTests: XCTestCase {
         let expected: [Statement<Int>] = [
             .variableDeclaration(
                 Token(type: .identifier, lexeme: "answer", line: 1),
-                .literal(.int(42))),
+                .literal(
+                    Token(type: .int, lexeme: "42", line: 1),
+                    .int(42))),
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -111,7 +117,9 @@ final class ResolverTests: XCTestCase {
                     [
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
-                            .literal(.int(42)))
+                            .literal(
+                                Token(type: .int, lexeme: "42", line: 2),
+                                .int(42)))
                     ])),
         ]
 
@@ -169,7 +177,9 @@ final class ResolverTests: XCTestCase {
             .block([
                 .return(
                     Token(type: .return, lexeme: "return", line: 1),
-                    .literal(.int(42))),
+                    .literal(
+                        Token(type: .int, lexeme: "42", line: 1),
+                        .int(42))),
             ])
         ]
 
@@ -333,7 +343,9 @@ final class ResolverTests: XCTestCase {
                             [
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
-                                    .literal(.int(42)))
+                                    .literal(
+                                        Token(type: .int, lexeme: "42", line: 3),
+                                        .int(42)))
                             ]))
                 ],
                 [])
@@ -516,7 +528,9 @@ final class ResolverTests: XCTestCase {
         // }
         let statements: [Statement<UnresolvedDepth>] = [
             .if(
-                .literal(.boolean(true)),
+                .literal(
+                    Token(type: .true, lexeme: "true", line: 1),
+                    .boolean(true)),
                 .break(Token(type: .break, lexeme: "break", line: 2)),
                 nil)
         ]
@@ -538,7 +552,9 @@ final class ResolverTests: XCTestCase {
         //}
         let statements: [Statement<UnresolvedDepth>] = [
             .while(
-                .literal(.boolean(true)),
+                .literal(
+                    Token(type: .true, lexeme: "true", line: 1),
+                    .boolean(true)),
                 .block([
                     .function(
                         Token(type: .identifier, lexeme: "foo", line: 2),
@@ -573,9 +589,15 @@ final class ResolverTests: XCTestCase {
                 .splat(
                     Token(type: .star, lexeme: "*", line: 1),
                     .list([
-                        .literal(.int(1)),
-                        .literal(.int(2)),
-                        .literal(.int(3)),
+                        .literal(
+                            Token(type: .int, lexeme: "1", line: 1),
+                            .int(1)),
+                        .literal(
+                            Token(type: .int, lexeme: "2", line: 1),
+                            .int(2)),
+                        .literal(
+                            Token(type: .int, lexeme: "3", line: 1),
+                            .int(3)),
                     ])))
         ]
 
@@ -624,7 +646,9 @@ final class ResolverTests: XCTestCase {
         let statements: [Statement<UnresolvedDepth>] = [
             .switch(
                 Token(type: .switch, lexeme: "switch", line: 1),
-                .literal(.int(42)),
+                .literal(
+                    Token(type: .int, lexeme: "42", line: 1),
+                    .int(42)),
                 [])
         ]
 
@@ -643,12 +667,16 @@ final class ResolverTests: XCTestCase {
         let statements: [Statement<UnresolvedDepth>] = [
             .switch(
                 Token(type: .switch, lexeme: "switch", line: 1),
-                .literal(.int(42)),
+                .literal(
+                    Token(type: .int, lexeme: "42", line: 1),
+                    .int(42)),
                 [
                     SwitchCaseDeclaration(
                         caseToken: Token(type: .case, lexeme: "case", line: 2),
                         valueExpressions: [
-                            .literal(.int(42))
+                            .literal(
+                                Token(type: .int, lexeme: "42", line: 2),
+                                .int(42))
                         ],
                         statement: .block([]))
                 ])

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -63,7 +63,7 @@ final class ResolverTests: XCTestCase {
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
                     ]),
-                    [
+                    .block([
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
                             .binary(
@@ -74,7 +74,7 @@ final class ResolverTests: XCTestCase {
                                 .variable(
                                     Token(type: .identifier, lexeme: "b", line: 2),
                                     UnresolvedDepth()))),
-                    ])),
+                    ]))),
         ]
 
         var resolver = Resolver()
@@ -88,18 +88,18 @@ final class ResolverTests: XCTestCase {
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
                     ]),
-                    [
+                    .block([
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
                             .binary(
                                 .variable(
                                     Token(type: .identifier, lexeme: "a", line: 2),
-                                    0),
+                                    1),
                                 Token(type: .plus, lexeme: "+", line: 2),
                                 .variable(
                                     Token(type: .identifier, lexeme: "b", line: 2),
-                                    0))),
-                    ])),
+                                    1))),
+                    ]))),
         ]
         XCTAssertEqual(actual, expected)
     }
@@ -114,13 +114,13 @@ final class ResolverTests: XCTestCase {
                 .lambda(
                     Token(type: .identifier, lexeme: "answer", line: 1),
                     nil,
-                    [
+                    .block([
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
                             .literal(
                                 Token(type: .int, lexeme: "42", line: 2),
                                 .int(42)))
-                    ])),
+                    ]))),
         ]
 
         var resolver = Resolver()
@@ -257,7 +257,7 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "sayName", line: 2),
                             ParameterList(normalParameters: []),
-                            [
+                            .block([
                                 .print(
                                     Token(type: .print, lexeme: "print", line: 3),
                                     .get(
@@ -266,7 +266,7 @@ final class ResolverTests: XCTestCase {
                                             Token(type: .this, lexeme: "this", line: 3),
                                             UnresolvedDepth()),
                                         Token(type: .identifier, lexeme: "name", line: 3)))
-                            ]))
+                            ])))
                 ],
                 [])
         ]
@@ -283,16 +283,16 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "sayName", line: 2),
                             ParameterList(normalParameters: []),
-                            [
+                            .block([
                                 .print(
                                     Token(type: .print, lexeme: "print", line: 3),
                                     .get(
                                         Token(type: .dot, lexeme: ".", line: 3),
                                         .this(
                                             Token(type: .this, lexeme: "this", line: 3),
-                                            1),
+                                            2),
                                         Token(type: .identifier, lexeme: "name", line: 3)))
-                            ]))
+                            ])))
                 ],
                 [])
         ]
@@ -309,13 +309,13 @@ final class ResolverTests: XCTestCase {
                 .lambda(
                     Token(type: .identifier, lexeme: "foo", line: 1),
                     ParameterList(normalParameters: []),
-                    [
+                    .block([
                         .return(
                             Token(type: .return, lexeme: "return", line: 2),
                             .this(
                                 Token(type: .this, lexeme: "this", line: 2),
                                 UnresolvedDepth()))
-                    ])),
+                    ]))),
         ]
 
         var resolver = Resolver()
@@ -342,13 +342,13 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "init", line: 2),
                             ParameterList(normalParameters: []),
-                            [
+                            .block([
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
                                     .literal(
                                         Token(type: .int, lexeme: "42", line: 3),
                                         .int(42)))
-                            ]))
+                            ])))
                 ],
                 [])
         ]
@@ -381,7 +381,7 @@ final class ResolverTests: XCTestCase {
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
                             ]),
-                            [
+                            .block([
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
                                     .binary(
@@ -392,7 +392,7 @@ final class ResolverTests: XCTestCase {
                                         .variable(
                                             Token(type: .identifier, lexeme: "b", line: 3),
                                             UnresolvedDepth())))
-                            ]))
+                            ])))
                 ])
         ]
 
@@ -412,18 +412,18 @@ final class ResolverTests: XCTestCase {
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
                             ]),
-                            [
+                            .block([
                                 .return(
                                     Token(type: .return, lexeme: "return", line: 3),
                                     .binary(
                                         .variable(
                                             Token(type: .identifier, lexeme: "a", line: 3),
-                                            0),
+                                            1),
                                         Token(type: .plus, lexeme: "+", line: 3),
                                         .variable(
                                             Token(type: .identifier, lexeme: "b", line: 3),
-                                            0)))
-                            ]))
+                                            1)))
+                            ])))
                 ])
         ]
         XCTAssertEqual(actual, expected)
@@ -446,7 +446,7 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "init", line: 2),
                             ParameterList(normalParameters: []),
-                            [
+                            .block([
                                 .expression(
                                     .set(
                                         Token(type: .dot, lexeme: ".", line: 3),
@@ -455,7 +455,7 @@ final class ResolverTests: XCTestCase {
                                             UnresolvedDepth()),
                                         Token(type: .identifier, lexeme: "name", line: 3),
                                         .string(Token(type: .string, lexeme: "\"bad\"", line: 1))))
-                            ]))
+                            ])))
                 ])
         ]
 
@@ -501,7 +501,7 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "someMethod", line: 2),
                             ParameterList(normalParameters: []),
-                            [
+                            .block([
                                 .expression(
                                     .call(
                                         .super(
@@ -511,7 +511,7 @@ final class ResolverTests: XCTestCase {
                                         Token(type: .rightParen, lexeme: ")", line: 3),
                                         [])
                                 )
-                            ]))
+                            ])))
                 ],
                 [])
         ]
@@ -564,9 +564,9 @@ final class ResolverTests: XCTestCase {
                         .lambda(
                             Token(type: .identifier, lexeme: "foo", line: 2),
                             ParameterList(normalParameters: []),
-                            [
+                            .block([
                                 .break(Token(type: .break, lexeme: "break", line: 3))
-                            ])),
+                            ]))),
                     .expression(
                         .call(
                             .variable(

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -250,6 +250,7 @@ final class ResolverTests: XCTestCase {
                             [
                                 .print(
                                     .get(
+                                        Token(type: .dot, lexeme: ".", line: 3),
                                         .this(
                                             Token(type: .this, lexeme: "this", line: 3),
                                             UnresolvedDepth()),
@@ -274,6 +275,7 @@ final class ResolverTests: XCTestCase {
                             [
                                 .print(
                                     .get(
+                                        Token(type: .dot, lexeme: ".", line: 3),
                                         .this(
                                             Token(type: .this, lexeme: "this", line: 3),
                                             1),
@@ -433,6 +435,7 @@ final class ResolverTests: XCTestCase {
                             [
                                 .expression(
                                     .set(
+                                        Token(type: .dot, lexeme: ".", line: 3),
                                         .this(
                                             Token(type: .this, lexeme: "this", line: 3),
                                             UnresolvedDepth()),

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -528,6 +528,7 @@ final class ResolverTests: XCTestCase {
         // }
         let statements: [Statement<UnresolvedDepth>] = [
             .if(
+                Token(type: .if, lexeme: "if", line: 1),
                 .literal(
                     Token(type: .true, lexeme: "true", line: 1),
                     .boolean(true)),

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -259,6 +259,7 @@ final class ResolverTests: XCTestCase {
                             ParameterList(normalParameters: []),
                             [
                                 .print(
+                                    Token(type: .print, lexeme: "print", line: 3),
                                     .get(
                                         Token(type: .dot, lexeme: ".", line: 3),
                                         .this(
@@ -284,6 +285,7 @@ final class ResolverTests: XCTestCase {
                             ParameterList(normalParameters: []),
                             [
                                 .print(
+                                    Token(type: .print, lexeme: "print", line: 3),
                                     .get(
                                         Token(type: .dot, lexeme: ".", line: 3),
                                         .this(

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -52,6 +52,7 @@ final class ResolverTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "add", line: 1),
                 .lambda(
+                    Token(type: .identifier, lexeme: "add", line: 1),
                     ParameterList(normalParameters: [
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
@@ -76,6 +77,7 @@ final class ResolverTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "add", line: 1),
                 .lambda(
+                    Token(type: .identifier, lexeme: "add", line: 1),
                     ParameterList(normalParameters: [
                         Token(type: .identifier, lexeme: "a", line: 1),
                         Token(type: .identifier, lexeme: "b", line: 1),
@@ -104,6 +106,7 @@ final class ResolverTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "answer", line: 1),
                 .lambda(
+                    Token(type: .identifier, lexeme: "answer", line: 1),
                     nil,
                     [
                         .return(
@@ -113,7 +116,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.functionsMustHaveAParameterList
+        let locToken = Token(type: .identifier, lexeme: "answer", line: 1)
+        let expectedError = ResolverError.functionsMustHaveAParameterList(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -170,16 +174,17 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.cannotReturnOutsideFunction
+        let locToken = Token(type: .return, lexeme: "return", line: 1)
+        let expectedError = ResolverError.cannotReturnOutsideFunction(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
     }
 
     func testResolveVariableReferencedInItsOwnInitializer() throws {
-        // var a = "outer";
+        // var x = "outer";
         // {
-        //     var a = a;
+        //     var x = x;
         // }
         let statements: [Statement<UnresolvedDepth>] = [
             .variableDeclaration(
@@ -195,7 +200,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.variableAccessedBeforeInitialization
+        let locToken = Token(type: .identifier, lexeme: "x", line: 3)
+        let expectedError = ResolverError.variableAccessedBeforeInitialization(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -218,7 +224,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.variableAlreadyDefined("a")
+        let nameToken = Token(type: .identifier, lexeme: "a", line: 3)
+        let expectedError = ResolverError.variableAlreadyDefined(nameToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -238,6 +245,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "sayName", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "sayName", line: 2),
                             ParameterList(normalParameters: []),
                             [
                                 .print(
@@ -261,6 +269,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "sayName", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "sayName", line: 2),
                             ParameterList(normalParameters: []),
                             [
                                 .print(
@@ -284,6 +293,7 @@ final class ResolverTests: XCTestCase {
             .function(
                 Token(type: .identifier, lexeme: "foo", line: 1),
                 .lambda(
+                    Token(type: .identifier, lexeme: "foo", line: 1),
                     ParameterList(normalParameters: []),
                     [
                         .return(
@@ -295,7 +305,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.cannotReferenceThisOutsideClass
+        let locToken = Token(type: .this, lexeme: "this", line: 2)
+        let expectedError = ResolverError.cannotReferenceThisOutsideClass(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -315,6 +326,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "init", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "init", line: 2),
                             ParameterList(normalParameters: []),
                             [
                                 .return(
@@ -326,7 +338,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.cannotReturnValueFromInitializer
+        let locToken = Token(type: .return, lexeme: "return", line: 3)
+        let expectedError = ResolverError.cannotReturnValueFromInitializer(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -347,6 +360,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "add", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "add", line: 2),
                             ParameterList(normalParameters: [
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
@@ -377,6 +391,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "add", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "add", line: 2),
                             ParameterList(normalParameters: [
                                 Token(type: .identifier, lexeme: "a", line: 2),
                                 Token(type: .identifier, lexeme: "b", line: 2),
@@ -413,6 +428,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "init", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "init", line: 2),
                             ParameterList(normalParameters: []),
                             [
                                 .expression(
@@ -427,7 +443,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.staticInitsNotAllowed
+        let nameToken = Token(type: .identifier, lexeme: "init", line: 2)
+        let expectedError = ResolverError.staticInitsNotAllowed(nameToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -444,7 +461,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.cannotReferenceSuperOutsideClass
+        let locToken = Token(type: .super, lexeme: "super", line: 1)
+        let expectedError = ResolverError.cannotReferenceSuperOutsideClass(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -464,6 +482,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "someMethod", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "someMethod", line: 2),
                             ParameterList(normalParameters: []),
                             [
                                 .expression(
@@ -481,7 +500,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.cannotReferenceSuperWithoutSubclassing
+        let locToken = Token(type: .super, lexeme: "super", line: 3)
+        let expectedError = ResolverError.cannotReferenceSuperWithoutSubclassing(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -499,7 +519,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.cannotBreakOutsideLoopOrSwitch
+        let locToken = Token(type: .break, lexeme: "break", line: 2)
+        let expectedError = ResolverError.cannotBreakOutsideLoopOrSwitch(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -519,6 +540,7 @@ final class ResolverTests: XCTestCase {
                     .function(
                         Token(type: .identifier, lexeme: "foo", line: 2),
                         .lambda(
+                            Token(type: .identifier, lexeme: "foo", line: 2),
                             ParameterList(normalParameters: []),
                             [
                                 .break(Token(type: .break, lexeme: "break", line: 3))
@@ -534,7 +556,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.cannotBreakOutsideLoopOrSwitch
+        let locToken = Token(type: .break, lexeme: "break", line: 3)
+        let expectedError = ResolverError.cannotBreakOutsideLoopOrSwitch(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -545,6 +568,7 @@ final class ResolverTests: XCTestCase {
         let statements: [Statement<UnresolvedDepth>] = [
             .expression(
                 .splat(
+                    Token(type: .star, lexeme: "*", line: 1),
                     .list([
                         .literal(.int(1)),
                         .literal(.int(2)),
@@ -553,7 +577,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.cannotUseSplatOperatorOutOfContext
+        let locToken = Token(type: .star, lexeme: "*", line: 1)
+        let expectedError = ResolverError.cannotUseSplatOperatorOutOfContext(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -594,11 +619,15 @@ final class ResolverTests: XCTestCase {
         // switch (42) {
         // }
         let statements: [Statement<UnresolvedDepth>] = [
-            .switch(.literal(.int(42)), [])
+            .switch(
+                Token(type: .switch, lexeme: "switch", line: 1),
+                .literal(.int(42)),
+                [])
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.switchMustHaveAtLeastOneCaseOrDefault
+        let locToken = Token(type: .switch, lexeme: "switch", line: 1)
+        let expectedError = ResolverError.switchMustHaveAtLeastOneCaseOrDefault(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }
@@ -610,9 +639,11 @@ final class ResolverTests: XCTestCase {
         // }
         let statements: [Statement<UnresolvedDepth>] = [
             .switch(
+                Token(type: .switch, lexeme: "switch", line: 1),
                 .literal(.int(42)),
                 [
                     SwitchCaseDeclaration(
+                        caseToken: Token(type: .case, lexeme: "case", line: 2),
                         valueExpressions: [
                             .literal(.int(42))
                         ],
@@ -621,7 +652,8 @@ final class ResolverTests: XCTestCase {
         ]
 
         var resolver = Resolver()
-        let expectedError = ResolverError.switchMustHaveAtLeastOneStatementPerCaseOrDefault
+        let locToken = Token(type: .case, lexeme: "case", line: 2)
+        let expectedError = ResolverError.switchMustHaveAtLeastOneStatementPerCaseOrDefault(locToken)
         XCTAssertThrowsError(try resolver.resolve(statements: statements)) { actualError in
             XCTAssertEqual(actualError as! ResolverError, expectedError)
         }

--- a/sloxTests/ResolverTests.swift
+++ b/sloxTests/ResolverTests.swift
@@ -595,6 +595,7 @@ final class ResolverTests: XCTestCase {
         //}
         let statements: [Statement<UnresolvedDepth>] = [
             .while(
+                Token(type: .while, lexeme: "while", line: 1),
                 .literal(
                     Token(type: .true, lexeme: "true", line: 1),
                     .boolean(true)),


### PR DESCRIPTION
- All `Statement` and `Expression` AST nodes carry a location token, and each has a computed property, `locToken`, which returns that `Token`, which best represents the location of the respective statement or expression. The `==` method in `Expression` needed to be updated to account for the newly introduced `Token`s.
- `SwitchCaseDeclaration` also now carries a location token for the `case` keyword.
- All cases for `ResolverError` and most in `RuntimeError` now also carry a location `Token` so that its line number is displayed in the respective error message. 
- The changes above mean that the handlers in the parser, resolver, and interpreter all had to be modified, in some places more so that for others: the parser to pluck the relevant location token for each case, the resolver to pass it forward, and the interpreter ultimately to handle it if necessary, each passing the relevant location token to the relevant error.
- There are quite a few handlers in the resolver and interpreter which now call `fatalError()` instead of throw a user error because they should not happen due to anything the user has done.
- There are still a few cases in `RuntimeError` which do not have a location token, and that's because those errors are thrown from `NativeFunction.call()` where it is not possible to fetch one since we only have access to `LoxValue`s not `Expression`s. In those cases, the interpreter will catch the error and rethrow a new `RuntimeError`, namely `errorInCall` which effectively acts as a tiny call stack which when fully printed _will_ display line information. 
- There are quite a few cases in `NativeFunction` which call `fatalError()` instead of throwing a `RuntimeError` because the user should not encounter ever encounter those conditions unless something went terribly wrong internally and the interpreter should be halted.
- `LoxValue` no longer throws `RuntimeError`s and instead calls `fatalError()` for the same reasons as above.
- The `set()` method of `LoxInstance`, `LoxList`, `LoxEnum`, `LoxString`, and `LoxList` now take a `Token` value associated with a property name instead of simply the lexeme so that it can throw a `RuntimeError` with location information. The `get()` methods for each also take a full `Token`.
- Likewise, `getValue()`, `getValueAtDepth()`, and `assignAtDepth()` methods in `Environment` now all take a full `Token` instead of a lexeme so that the `RuntimeError` thrown can be associated with it.
- `ParameterList.checkArity()` now returns a boolean value instead of throws in the case of an error condition so that the interpreter can throw with the location information that only it has.
- `Interpreter` now has a new private helper method, `lookUpStandardLibraryClass()` which consolidates the logic to load the class instance for a given Lox class name, and call `fatalError()` in the event something went wrong with the initialization of the standard library.
- There was a subtle but important refactor involving `Interpreter` and `UserDefinedFunction` and certain `Expression` cases: blocks are no longer represented as a list of `Statement`s, including for `Expression.lambda` nodes, but instead as a top-level `Statement.block` node; previously there was some inconsistency in that representation.
- `UserDefinedFunction.call()` was slightly refactored to perform some environment management due to the changes above, which made the call to `Interpreter.handleBlock()` no longer work because scope depths would be off. Additionally, it now calls `Interpreter. handleStatement(), passing in the single block statement.
- _Many_ unit tests were updated per changes in the AST.
