### PR TITLE
Introduce private methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,26 @@ class Math {
 Math.add(1, 2)
 ```
 
+Methods can also be declared as `private` so that they cannot be called from outside a class, and for when you want users of your class to only call certain other methods. If `private` is not specified, then the method is public.
+
+```
+class ComplexCalculator {
+    doWork() {
+        this.doSomeWork();
+        this.doMoreWork();
+        print "Done!"
+    }
+
+    private doSomeWork() {
+        print "Crunching numbers...";
+    }
+
+    private doMoreWork() {
+        print "Performing final calculations...";
+    }
+}
+```
+
 You can also define computed properties in classes, which look just like functions but do not have an argument list nor parentheses:
 
 ```

--- a/examples/wordle.lox
+++ b/examples/wordle.lox
@@ -374,7 +374,7 @@ class Keyboard {
         }
     }
 
-    displayRow(row, indent) {
+    private displayRow(row, indent) {
         var output = indent;
         var letters = row.chars;
         for (var i = 0; i < row.count; i += 1) {
@@ -432,7 +432,7 @@ class Game {
         this.reset();
     }
 
-    display() {
+    private display() {
         print Terminal.clearScreenStr();
         for (var i = 0; i < this.guesses.count; i += 1) {
             this.guesses[i].display();
@@ -451,7 +451,7 @@ class Game {
         }
     }
 
-    reset() {
+    private reset() {
         for (var i = 0; i < 6; i += 1) {
             this.guesses[i].reset();
         }
@@ -462,7 +462,7 @@ class Game {
         this.word = this.wordList.choose();
     }
 
-    submitGuess(guess) {
+    private submitGuess(guess) {
         if (guess.chars.count != 5) {
             this.status = GameStatus.invalidGuess;
             return;

--- a/slox/Expression.swift
+++ b/slox/Expression.swift
@@ -69,6 +69,15 @@ indirect enum Expression<Depth: Equatable>: Equatable {
         }
     }
 
+    var isThis: Bool {
+        switch self {
+        case .this:
+            return true
+        default:
+            return false
+        }
+    }
+
     static func == (lhs: Expression, rhs: Expression) -> Bool {
         switch (lhs, rhs) {
         case (.binary(let lhsExpr1, let lhsOper, let lhsExpr2), .binary(let rhsExpr1, let rhsOper, let rhsExpr2)):

--- a/slox/LoxClass.swift
+++ b/slox/LoxClass.swift
@@ -46,12 +46,14 @@ class LoxClass: LoxInstance, LoxCallable {
         super.init(klass: klass)
     }
 
-    func findMethod(name: String) -> UserDefinedFunction? {
+    func findMethod(name: String, includePrivate: Bool) -> UserDefinedFunction? {
         if let method = methods[name] {
-            return method
+            if includePrivate || !method.isPrivate {
+                return method
+            }
         }
 
-        return superclass?.findMethod(name: name)
+        return superclass?.findMethod(name: name, includePrivate: includePrivate)
     }
 
     func call(interpreter: Interpreter, args: [LoxValue]) throws -> LoxValue {

--- a/slox/LoxDictionary.swift
+++ b/slox/LoxDictionary.swift
@@ -18,12 +18,12 @@ class LoxDictionary: LoxInstance {
         super.init(klass: klass)
     }
 
-    override func get(propertyName: Token) throws -> LoxValue {
+    override func get(propertyName: Token, includePrivate: Bool) throws -> LoxValue {
         switch propertyName.lexeme {
         case "count":
             return .int(self.kvPairs.count)
         default:
-            return try super.get(propertyName: propertyName)
+            return try super.get(propertyName: propertyName, includePrivate: includePrivate)
         }
     }
 

--- a/slox/LoxInstance.swift
+++ b/slox/LoxInstance.swift
@@ -32,12 +32,12 @@ class LoxInstance {
         self._klass = klass
     }
 
-    func get(propertyName: Token) throws -> LoxValue {
+    func get(propertyName: Token, includePrivate: Bool) throws -> LoxValue {
         if let propertyValue = self.properties[propertyName.lexeme] {
             return propertyValue
         }
 
-        if let method = klass.findMethod(name: propertyName.lexeme) {
+        if let method = klass.findMethod(name: propertyName.lexeme, includePrivate: includePrivate) {
             let boundMethod = method.bind(instance: self)
             return .userDefinedFunction(boundMethod)
         }

--- a/slox/LoxList.swift
+++ b/slox/LoxList.swift
@@ -21,12 +21,12 @@ class LoxList: LoxInstance {
         super.init(klass: klass)
     }
 
-    override func get(propertyName: Token) throws -> LoxValue {
+    override func get(propertyName: Token, includePrivate: Bool) throws -> LoxValue {
         switch propertyName.lexeme {
         case "count":
             return .int(elements.count)
         default:
-            return try super.get(propertyName: propertyName)
+            return try super.get(propertyName: propertyName, includePrivate: includePrivate)
         }
     }
 

--- a/slox/LoxString.swift
+++ b/slox/LoxString.swift
@@ -20,12 +20,12 @@ class LoxString: LoxInstance {
         super.init(klass: klass)
     }
 
-    override func get(propertyName: Token) throws -> LoxValue {
+    override func get(propertyName: Token, includePrivate: Bool) throws -> LoxValue {
         switch propertyName.lexeme {
         case "count":
             return .int(string.count)
         default:
-            return try super.get(propertyName: propertyName)
+            return try super.get(propertyName: propertyName, includePrivate: includePrivate)
         }
     }
 

--- a/slox/ParseError.swift
+++ b/slox/ParseError.swift
@@ -45,6 +45,7 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
     case missingDotAfterSuper(Token)
     case expectedSuperclassMethodName(Token)
     case missingCloseBracketForSubscriptAccess(Token)
+    case duplicateModifier(Token)
 
     var description: String {
         switch self {
@@ -122,6 +123,8 @@ enum ParseError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(token.line)] Error: expected superclass method name"
         case .missingCloseBracketForSubscriptAccess(let token):
             return "[Line \(token.line)] Error: expected closing bracket after subscript index"
+        case .duplicateModifier(let token):
+            return "[Line \(token.line)] Error: modifier already specified: `\(token.lexeme)`"
         }
     }
 }

--- a/slox/Parser.swift
+++ b/slox/Parser.swift
@@ -118,7 +118,12 @@ struct Parser {
             // calling `parseFunction()`. That's a deliberate design decision
             // by the original author.
             var modifierTokens: [Token] = []
-            if currentTokenMatchesAny(types: [.class]) {
+            while currentTokenMatchesAny(types: [.class, .private]) {
+                if modifierTokens.contains(where: { token in
+                    token.type == previousToken.type
+                }) {
+                    throw ParseError.duplicateModifier(previousToken)
+                }
                 modifierTokens.append(previousToken)
             }
             let methodStatement = try parseFunction(modifierTokens: modifierTokens)
@@ -154,10 +159,15 @@ struct Parser {
                 enumCases.append(contentsOf: newEnumCases)
             } else {
                 var modifierTokens: [Token] = []
-                if currentTokenMatchesAny(types: [.class]) {
-                    // It's a little weird to look for the "class" keyword here
-                    // for an enum, but we want to be consistent with the Lox specification,
-                    // and enums are _somewhat_ like classes anyway
+                // It's a little weird to look for the "class" keyword here
+                // for an enum, but we want to be consistent with the Lox specification,
+                // and enums are _somewhat_ like classes anyway
+                while currentTokenMatchesAny(types: [.class, .private]) {
+                    if modifierTokens.contains(where: { token in
+                        token.type == previousToken.type
+                    }) {
+                        throw ParseError.duplicateModifier(previousToken)
+                    }
                     modifierTokens.append(previousToken)
                 }
                 let method = try parseFunction(modifierTokens: modifierTokens)

--- a/slox/Scanner.swift
+++ b/slox/Scanner.swift
@@ -35,7 +35,8 @@ struct Scanner {
         "enum": .enum,
         "case": .case,
         "switch": .switch,
-        "default": .default
+        "default": .default,
+        "private": .private,
     ]
 
     init(source: String) {

--- a/slox/TokenType.swift
+++ b/slox/TokenType.swift
@@ -66,6 +66,7 @@ enum TokenType: Equatable {
     case `case`
     case `switch`
     case `default`
+    case `private`
 
     case eof
 }

--- a/slox/UserDefinedFunction.swift
+++ b/slox/UserDefinedFunction.swift
@@ -12,6 +12,7 @@ struct UserDefinedFunction: LoxCallable, Equatable {
     var enclosingEnvironment: Environment
     var body: Statement<Int>
     var isInitializer: Bool
+    var isPrivate: Bool
     var objectId: UUID
     var parameterList: ParameterList? = nil
 
@@ -23,12 +24,14 @@ struct UserDefinedFunction: LoxCallable, Equatable {
          parameterList: ParameterList?,
          enclosingEnvironment: Environment,
          body: Statement<Int>,
-         isInitializer: Bool) {
+         isInitializer: Bool,
+         isPrivate: Bool) {
         self.name = name
         self.parameterList = parameterList
         self.enclosingEnvironment = enclosingEnvironment
         self.body = body
         self.isInitializer = isInitializer
+        self.isPrivate = isPrivate
         self.objectId = UUID()
     }
 
@@ -84,6 +87,7 @@ struct UserDefinedFunction: LoxCallable, Equatable {
                                    parameterList: parameterList,
                                    enclosingEnvironment: newEnvironment,
                                    body: body,
-                                   isInitializer: isInitializer)
+                                   isInitializer: isInitializer,
+                                   isPrivate: isPrivate)
     }
 }

--- a/sloxTests/ScannerTests.swift
+++ b/sloxTests/ScannerTests.swift
@@ -112,7 +112,7 @@ final class ScannerTests: XCTestCase {
     }
 
     func testScanningOfKeywords() throws {
-        let source = "and class else false for fun if nil or print return super this true var while break continue enum case"
+        let source = "and class else false for fun if nil or print return super this true var while break continue enum case default private"
         var scanner = Scanner(source: source)
         let actual = try! scanner.scanTokens()
         let expected: [Token] = [
@@ -136,6 +136,8 @@ final class ScannerTests: XCTestCase {
             Token(type: .continue, lexeme: "continue", line: 1),
             Token(type: .enum, lexeme: "enum", line: 1),
             Token(type: .case, lexeme: "case", line: 1),
+            Token(type: .default, lexeme: "default", line: 1),
+            Token(type: .private, lexeme: "private", line: 1),
             Token(type: .eof, lexeme: "", line: 1),
         ]
 


### PR DESCRIPTION
The main goal of this PR is to allow for classes and enums to declare private methods, both at the class and instance level. The following changes were made in order to achieve that:

- Introduction of new keyword, `private`, and the scanner now looks for and lexes it.
- The previous PR allows for `.function` AST nodes to have a list of modifier tokens; the parser now looks for the new keyword and puts it in the list if encountered. It should be noted that `class` and `private` can appear in any order, and the parser will throw a new `ParseError` if either one of them appears more than once.
- No changes were made to the resolver.
- `UserDefinedFunction` now carries a new `isPrivate` boolean flag.
- `LoxInstance.get()` now takes another parameter, `includePrivate`. It ignores the parameter when looking up properties, since there is no notion of a private property. If none is found, then it calls `LoxClass.findMethod()` for the corresponing `klass`, passing on the `includePrivate` value. That also meant the signature of `get()` for subclasses of `LoxInstance` had to be updated to also take the new parameter.
- `LoxClass.findMethod() also now takes an `includePrivate` parameter. If it finds a method with a matching name, it then considers the new flag: if it is true, then it returns the `UserDefinedFunction` instance; if not, then it only returns the method if it is _not_ private.
- `Expression` has a new computed property `isThis` which only returns true if it is a `.this` case.
- The changes to the interpreter were made in several places:
  - For both class and enum declarations, `makeMethodLookup()` checks if the `private` token is in the list for each `.function` AST node, and instantiates a `UserDefinedFunction` with the `isPrivate` flag set to `true`, otherwise it is set to `false`. Method lookup tables are otherwise assembled exactly the same way.
  - `handleGetExpression()` now passes on the value of `isThis` for the callee expression. In other words, the only time we should allow a private method lookup is when the expression in question is a `this` expression. The only time we would ever encounter one is if it appears inside the method of a class; the resolver would have caught any attempts at evaluating `this.someMethod()` outside a class.
  - `handleSuperExpression()` now always passes `true` for the `includePrivate` parameter when calling `findMethod()` for the superclass. This is the desired behavior as all of a superclasses methods should be made available to a superclass when making an internal call. Likewise, a call to `super.someMethod()` outside of a class is already disallowed by the resolver.
- Relevant unit tests were added for the parser and the interpreter.
- The Wordle example now takes advantage of private methods.