### PR TITLE
Support multiline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ var x = 21;
 x *= 2;
 ```
 
+### Comments
+
+Comments can either be at the end of a line using a double slash:
+
+```
+var x = 42; // This is the answer.
+```
+
+... or they can be across multiple lines using slash-star at the beginning and star-slash at the end:
+
+```
+/*
+ * This is the answer
+ */
+var x = 42;
+```
+
 ### Flow control
 
 There are four types of flow control statements in slox, two of which are non-looping constructs: `if` blocks:

--- a/slox/ScanError.swift
+++ b/slox/ScanError.swift
@@ -10,6 +10,7 @@ import Foundation
 enum ScanError: CustomStringConvertible, Equatable, LocalizedError {
     case unterminatedString(Int)
     case unexpectedCharacter(Int)
+    case unterminatedComment(Int)
 
     var description: String {
         switch self {
@@ -17,6 +18,8 @@ enum ScanError: CustomStringConvertible, Equatable, LocalizedError {
             return "[Line \(line)] Error: unterminated string"
         case .unexpectedCharacter(let line):
             return "[Line \(line)] Error: unexpected character"
+        case .unterminatedComment(let line):
+            return "[Line \(line)] Error: unterminated comment"
         }
     }
 }

--- a/slox/Scanner.swift
+++ b/slox/Scanner.swift
@@ -76,12 +76,16 @@ struct Scanner {
     }
 
     mutating private func tryNotScan(string: String) throws -> Bool {
-        // TODO: Also need to count lines when \n encountered in comment
+        precondition(!string.dropFirst().contains("\n"), "newlines in `string` would mess with line counting")
         let oldIndex = currentIndex
 
         for char in string {
             guard currentIndex < self.source.endIndex else {
                 throw ScanError.unterminatedComment(self.line)
+            }
+
+            if self.source[self.currentIndex] == "\n" {
+                self.line += 1
             }
 
             if !tryScan(char) {


### PR DESCRIPTION
This PR introduces support for multiline comments, using the standard `/* ... */` style. In order to accomplish this, I needed to to the folllowing:

* Extended functionality in `handleSlash()`
* Added a new overload of `tryNotScan()` which can now take a string and will continue scanning until it either finds that string or errors out if not matched
* There is a new error case for `ScanError`, namely `unterminatedComment`
* Since the new flavor of `tryNotScan()` can throw, `repeatedly()` also needed to annotated with `throws`, which meant `try` needed to be put in front of all other functions which use it.

There is also unit test coverage for this new feature.